### PR TITLE
Fix merge conflict on `fill_algo_branch1`

### DIFF
--- a/stl/inc/algorithm
+++ b/stl/inc/algorithm
@@ -2389,7 +2389,7 @@ namespace ranges {
             template <class _T, output_iterator<const _T&> _O>
             constexpr _O operator()(_O _First, iter_difference_t<_O> _Count, const _T& _Value) const {
                 auto _UFirst = _Get_unwrapped_n(_STD move(_First), _Count);
-                for (; _Count > 0; ++_UFirst, --_Count) {
+                for (; _Count > 0; ++_UFirst, (void) --_Count) {
                     *_UFirst = _Value;
                 }
 

--- a/stl/inc/condition_variable
+++ b/stl/inc/condition_variable
@@ -27,8 +27,7 @@ _STL_DISABLE_CLANG_WARNINGS
 _STD_BEGIN
 class condition_variable_any { // class for waiting for conditions with any kind of mutex
 public:
-    condition_variable_any() {
-        _Myptr = _STD make_shared<mutex>();
+    condition_variable_any() : _Myptr{_STD make_shared<mutex>()} {
         _Cnd_init_in_situ(_Mycnd());
     }
 
@@ -40,38 +39,58 @@ public:
     condition_variable_any& operator=(const condition_variable_any&) = delete;
 
     void notify_one() noexcept { // wake up one waiter
-        lock_guard<mutex> _Lck(*_Myptr);
-        _Check_C_return(_Cnd_signal(_Mycnd()));
+        lock_guard<mutex> _Guard{*_Myptr};
+        _Cnd_signal(_Mycnd());
     }
 
     void notify_all() noexcept { // wake up all waiters
-        lock_guard<mutex> _Lck(*_Myptr);
-        _Check_C_return(_Cnd_broadcast(_Mycnd()));
+        lock_guard<mutex> _Guard{*_Myptr};
+        _Cnd_broadcast(_Mycnd());
     }
 
-    template <class _Mutex>
-    void wait(_Mutex& _Xtrnl) { // wait for signal
+    template <class _Lock>
+    void wait(_Lock& _Lck) noexcept /* terminates */ { // wait for signal
         {
-            shared_ptr<mutex> _Ptr = _Myptr; // for immunity to *this destruction
-            lock_guard<mutex> _Lck(*_Ptr);
-            _Xtrnl.unlock(); // could throw
-            _Check_C_return(_Cnd_wait(_Mycnd(), _Ptr->_Mymtx()));
+            const shared_ptr<mutex> _Ptr = _Myptr; // for immunity to *this destruction
+            lock_guard<mutex> _Guard{*_Ptr};
+            _Lck.unlock();
+            _Cnd_wait(_Mycnd(), _Ptr->_Mymtx());
         } // unlock
 
-        _Relock(_Xtrnl);
+        _Lck.lock();
     }
 
-    template <class _Mutex, class _Predicate>
-    void wait(_Mutex& _Xtrnl, _Predicate _Pred) { // wait for signal and check predicate
+    template <class _Lock, class _Predicate>
+    void wait(_Lock& _Lck, _Predicate _Pred) noexcept(noexcept(!_Pred())) /* strengthened */ {
+        // wait for signal and check predicate
         while (!_Pred()) {
-            wait(_Xtrnl);
+            wait(_Lck);
         }
     }
 
+    template <class _Lock, class _Clock, class _Duration>
+    cv_status wait_until(_Lock& _Lck, const chrono::time_point<_Clock, _Duration>& _Abs_time) {
+        // wait until time point
+        return wait_for(_Lck, _Abs_time - _Clock::now());
+    }
+
+    template <class _Lock, class _Clock, class _Duration, class _Predicate>
+    bool wait_until(_Lock& _Lck, const chrono::time_point<_Clock, _Duration>& _Abs_time, _Predicate _Pred) {
+        // wait for signal with timeout and check predicate
+        while (!_Pred()) {
+            if (wait_until(_Lck, _Abs_time) == cv_status::timeout) {
+                return _Pred();
+            }
+        }
+
+        return true;
+    }
+
     template <class _Lock, class _Rep, class _Period>
-    cv_status wait_for(_Lock& _Lck, const chrono::duration<_Rep, _Period>& _Rel_time) {
-        // wait for duration
+    cv_status wait_for(_Lock& _Lck, const chrono::duration<_Rep, _Period>& _Rel_time) { // wait for duration
         if (_Rel_time <= chrono::duration<_Rep, _Period>::zero()) {
+            _Lck.unlock();
+            _Relock(_Lck);
             return cv_status::timeout;
         }
 
@@ -79,7 +98,7 @@ public:
         // but unfortunately our ABI speaks struct xtime, which is relative to the system clock.
         _CSTD xtime _Tgt;
         const bool _Clamped     = _To_xtime_10_day_clamped(_Tgt, _Rel_time);
-        const cv_status _Result = wait_until(_Lck, &_Tgt);
+        const cv_status _Result = _Wait_until(_Lck, &_Tgt);
         if (_Clamped) {
             return cv_status::no_timeout;
         }
@@ -90,46 +109,46 @@ public:
     template <class _Lock, class _Rep, class _Period, class _Predicate>
     bool wait_for(_Lock& _Lck, const chrono::duration<_Rep, _Period>& _Rel_time, _Predicate _Pred) {
         // wait for signal with timeout and check predicate
-        return _Wait_until1(_Lck, chrono::steady_clock::now() + _Rel_time, _Pred);
+        return wait_until(_Lck, chrono::steady_clock::now() + _Rel_time, _STD move(_Pred));
     }
 
-    template <class _Lock, class _Clock, class _Duration>
-    cv_status wait_until(_Lock& _Lck, const chrono::time_point<_Clock, _Duration>& _Abs_time) {
-        // wait until time point
-        for (;;) {
-            const auto _Now = _Clock::now();
-            if (_Abs_time <= _Now) {
-                return cv_status::timeout;
-            }
+    template <class _Lock>
+    cv_status wait_until(_Lock& _Lck, const xtime* const _Abs_time) { // wait for signal with timeout
+        return _Wait_until(_Lck, _Abs_time);
+    }
 
-            _CSTD xtime _Tgt;
-            (void) _To_xtime_10_day_clamped(_Tgt, _Abs_time - _Now);
-            const cv_status _Result = wait_until(_Lck, &_Tgt);
-            if (_Result == cv_status::no_timeout) {
-                return cv_status::no_timeout;
+    template <class _Lock, class _Predicate>
+    bool wait_until(_Lock& _Lck, const xtime* const _Abs_time, _Predicate _Pred) {
+        // wait for signal with timeout and check predicate
+        while (!_Pred()) {
+            if (_Wait_until(_Lck, _Abs_time) == cv_status::timeout) {
+                return _Pred();
             }
         }
+        return true;
     }
 
-    template <class _Lock, class _Clock, class _Duration, class _Predicate>
-    bool wait_until(_Lock& _Lck, const chrono::time_point<_Clock, _Duration>& _Abs_time, _Predicate _Pred) {
-        // wait for signal with timeout and check predicate
-        return _Wait_until1(_Lck, _Abs_time, _Pred);
+private:
+    shared_ptr<mutex> _Myptr;
+
+    aligned_storage_t<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment> _Cnd_storage;
+
+    _NODISCARD _Cnd_t _Mycnd() noexcept { // get pointer to _Cnd_internal_imp_t inside _Cnd_storage
+        return reinterpret_cast<_Cnd_t>(&_Cnd_storage);
     }
 
-    template <class _Mutex>
-    cv_status wait_until(_Mutex& _Xtrnl, const xtime* _Abs_time) {
-        // wait for signal with timeout
+    template <class _Lock>
+    cv_status _Wait_until(_Lock& _Lck, const xtime* const _Abs_time) { // wait for signal with timeout
         int _Res;
 
         {
-            shared_ptr<mutex> _Ptr = _Myptr; // for immunity to *this destruction
-            lock_guard<mutex> _Lck(*_Ptr);
-            _Xtrnl.unlock(); // could throw
+            const shared_ptr<mutex> _Ptr = _Myptr; // for immunity to *this destruction
+            lock_guard<mutex> _Guard{*_Ptr};
+            _Lck.unlock();
             _Res = _Cnd_timedwait(_Mycnd(), _Ptr->_Mymtx(), _Abs_time);
         } // unlock
 
-        _Relock(_Xtrnl);
+        _Relock(_Lck);
 
         switch (_Res) {
         case _Thrd_success:
@@ -141,57 +160,11 @@ public:
         }
     }
 
-    template <class _Mutex, class _Predicate>
-    bool wait_until(_Mutex& _Xtrnl, const xtime* _Abs_time, _Predicate _Pred) {
-        // wait for signal with timeout and check predicate
-        return _Wait_until1(_Xtrnl, _Abs_time, _Pred);
-    }
-
-private:
-    shared_ptr<mutex> _Myptr;
-
-    aligned_storage_t<_Cnd_internal_imp_size, _Cnd_internal_imp_alignment> _Cnd_storage;
-
-    _Cnd_t _Mycnd() noexcept { // get pointer to _Cnd_internal_imp_t inside _Cnd_storage
-        return reinterpret_cast<_Cnd_t>(&_Cnd_storage);
-    }
-
-    template <class _Mutex>
-    static void _Relock(_Mutex& _Xtrnl) noexcept /* terminates */ {
-        // relocks external mutex, terminate() on failure
-        // LWG-2135 says terminate rather than leaving the mutex unlocked;
-        // we slam into noexcept here for that for easier user debugging
-        _Xtrnl.lock();
-    }
-
-    template <class _Mutex, class _Predicate>
-    bool _Wait_until1(_Mutex& _Xtrnl, const xtime* _Abs_time, _Predicate& _Pred) {
-        // wait for signal with timeout and check predicate, without copying/moving the predicate
-        while (!_Pred()) {
-            if (wait_until(_Xtrnl, _Abs_time) == cv_status::timeout) {
-                return _Pred();
-            }
-        }
-
-        return true;
-    }
-
-    template <class _Mutex, class _Clock, class _Duration, class _Predicate>
-    bool _Wait_until1(_Mutex& _Xtrnl, const chrono::time_point<_Clock, _Duration>& _Abs_time, _Predicate& _Pred) {
-        while (!_Pred()) {
-            const auto _Now = _Clock::now();
-            if (_Abs_time <= _Now) {
-                return false;
-            }
-
-            _CSTD xtime _Tgt;
-            const bool _Clamped = _To_xtime_10_day_clamped(_Tgt, _Abs_time - _Now);
-            if (wait_until(_Xtrnl, &_Tgt) == cv_status::timeout && !_Clamped) {
-                return _Pred();
-            }
-        }
-
-        return true;
+    template <class _Lock>
+    static void _Relock(_Lock& _Lck) noexcept /* terminates */ { // relock external mutex or terminate()
+        // Wait functions are required to terminate if the mutex cannot be locked;
+        // we slam into noexcept here for easier user debugging.
+        _Lck.lock();
     }
 };
 

--- a/stl/inc/mutex
+++ b/stl/inc/mutex
@@ -64,7 +64,7 @@ public:
     }
 
     void unlock() {
-        _Check_C_return(_Mtx_unlock(_Mymtx()));
+        _Mtx_unlock(_Mymtx());
     }
 
     using native_handle_type = void*;
@@ -587,16 +587,16 @@ public:
     condition_variable& operator=(const condition_variable&) = delete;
 
     void notify_one() noexcept { // wake up one waiter
-        _Check_C_return(_Cnd_signal(_Mycnd()));
+        _Cnd_signal(_Mycnd());
     }
 
     void notify_all() noexcept { // wake up all waiters
-        _Check_C_return(_Cnd_broadcast(_Mycnd()));
+        _Cnd_broadcast(_Mycnd());
     }
 
     void wait(unique_lock<mutex>& _Lck) { // wait for signal
         // Nothing to do to comply with LWG-2135 because std::mutex lock/unlock are nothrow
-        _Check_C_return(_Cnd_wait(_Mycnd(), _Lck.mutex()->_Mymtx()));
+        _Cnd_wait(_Mycnd(), _Lck.mutex()->_Mymtx());
     }
 
     template <class _Predicate>

--- a/stl/inc/optional
+++ b/stl/inc/optional
@@ -53,10 +53,17 @@ protected:
     _THROW(bad_optional_access{});
 }
 
+struct _Nontrivial_dummy_type {
+    constexpr _Nontrivial_dummy_type() noexcept {
+        // This default constructor is user-provided to avoid zero-initialization when objects are value-initialized.
+    }
+};
+_STL_INTERNAL_STATIC_ASSERT(!is_trivially_default_constructible_v<_Nontrivial_dummy_type>);
+
 template <class _Ty, bool = is_trivially_destructible_v<_Ty>>
 struct _Optional_destruct_base { // either contains a value of _Ty or is empty (trivial destructor)
     union {
-        char _Dummy;
+        _Nontrivial_dummy_type _Dummy;
         remove_const_t<_Ty> _Value;
     };
     bool _Has_value;
@@ -75,7 +82,7 @@ struct _Optional_destruct_base { // either contains a value of _Ty or is empty (
 template <class _Ty>
 struct _Optional_destruct_base<_Ty, false> { // either contains a value of _Ty or is empty (non-trivial destructor)
     union {
-        char _Dummy;
+        _Nontrivial_dummy_type _Dummy;
         remove_const_t<_Ty> _Value;
     };
     bool _Has_value;
@@ -164,8 +171,8 @@ public:
     using value_type = _Ty;
 
     // constructors [optional.object.ctor]
-    constexpr optional() noexcept : _Mybase{} {}
-    constexpr optional(nullopt_t) noexcept : _Mybase{} {}
+    constexpr optional() noexcept {}
+    constexpr optional(nullopt_t) noexcept {}
 
     template <class... _Types, enable_if_t<is_constructible_v<_Ty, _Types...>, int> = 0>
     constexpr explicit optional(in_place_t, _Types&&... _Args) : _Mybase(in_place, _STD forward<_Types>(_Args)...) {}

--- a/stl/inc/xthreads.h
+++ b/stl/inc/xthreads.h
@@ -82,7 +82,7 @@ _CRTIMP2_PURE int __cdecl _Mtx_current_owns(_Mtx_t);
 _CRTIMP2_PURE int __cdecl _Mtx_lock(_Mtx_t);
 _CRTIMP2_PURE int __cdecl _Mtx_trylock(_Mtx_t);
 _CRTIMP2_PURE int __cdecl _Mtx_timedlock(_Mtx_t, const xtime*);
-_CRTIMP2_PURE int __cdecl _Mtx_unlock(_Mtx_t);
+_CRTIMP2_PURE int __cdecl _Mtx_unlock(_Mtx_t); // TRANSITION, ABI: always returns _Thrd_success
 
 _CRTIMP2_PURE void* __cdecl _Mtx_getconcrtcs(_Mtx_t);
 _CRTIMP2_PURE void __cdecl _Mtx_clear_owner(_Mtx_t);
@@ -103,10 +103,10 @@ _CRTIMP2_PURE int __cdecl _Cnd_init(_Cnd_t*);
 _CRTIMP2_PURE void __cdecl _Cnd_destroy(_Cnd_t);
 _CRTIMP2_PURE void __cdecl _Cnd_init_in_situ(_Cnd_t);
 _CRTIMP2_PURE void __cdecl _Cnd_destroy_in_situ(_Cnd_t);
-_CRTIMP2_PURE int __cdecl _Cnd_wait(_Cnd_t, _Mtx_t);
+_CRTIMP2_PURE int __cdecl _Cnd_wait(_Cnd_t, _Mtx_t); // TRANSITION, ABI: Always returns _Thrd_success
 _CRTIMP2_PURE int __cdecl _Cnd_timedwait(_Cnd_t, _Mtx_t, const xtime*);
-_CRTIMP2_PURE int __cdecl _Cnd_broadcast(_Cnd_t);
-_CRTIMP2_PURE int __cdecl _Cnd_signal(_Cnd_t);
+_CRTIMP2_PURE int __cdecl _Cnd_broadcast(_Cnd_t); // TRANSITION, ABI: Always returns _Thrd_success
+_CRTIMP2_PURE int __cdecl _Cnd_signal(_Cnd_t); // TRANSITION, ABI: Always returns _Thrd_success
 _CRTIMP2_PURE void __cdecl _Cnd_register_at_thread_exit(_Cnd_t, _Mtx_t, int*);
 _CRTIMP2_PURE void __cdecl _Cnd_unregister_at_thread_exit(_Mtx_t);
 _CRTIMP2_PURE void __cdecl _Cnd_do_broadcast_at_thread_exit();

--- a/stl/src/cond.cpp
+++ b/stl/src/cond.cpp
@@ -15,7 +15,9 @@ struct _Cnd_internal_imp_t { // condition variable implementation for ConcRT
     std::aligned_storage_t<Concurrency::details::stl_condition_variable_max_size,
         Concurrency::details::stl_condition_variable_max_alignment>
         cv;
-    Concurrency::details::stl_condition_variable_interface* _get_cv() { // get pointer to implementation
+
+    [[nodiscard]] Concurrency::details::stl_condition_variable_interface* _get_cv() noexcept {
+        // get pointer to implementation
         return reinterpret_cast<Concurrency::details::stl_condition_variable_interface*>(&cv);
     }
 };
@@ -24,38 +26,46 @@ static_assert(sizeof(_Cnd_internal_imp_t) <= _Cnd_internal_imp_size, "incorrect 
 static_assert(std::alignment_of<_Cnd_internal_imp_t>::value <= _Cnd_internal_imp_alignment,
     "incorrect _Cnd_internal_imp_alignment");
 
-void _Cnd_init_in_situ(_Cnd_t cond) { // initialize condition variable in situ
+void _Cnd_init_in_situ(const _Cnd_t cond) { // initialize condition variable in situ
     Concurrency::details::create_stl_condition_variable(cond->_get_cv());
 }
 
-void _Cnd_destroy_in_situ(_Cnd_t cond) { // destroy condition variable in situ
+void _Cnd_destroy_in_situ(const _Cnd_t cond) { // destroy condition variable in situ
     cond->_get_cv()->destroy();
 }
 
-int _Cnd_init(_Cnd_t* pcond) { // initialize
-    _Cnd_t cond;
-    *pcond = 0;
+int _Cnd_init(_Cnd_t* const pcond) { // initialize
+    *pcond = nullptr;
 
-    if ((cond = static_cast<_Cnd_t>(_calloc_crt(1, sizeof(struct _Cnd_internal_imp_t)))) == 0) {
+    const auto cond = static_cast<_Cnd_t>(_calloc_crt(1, sizeof(_Cnd_internal_imp_t)));
+    if (cond == nullptr) {
         return _Thrd_nomem; // report alloc failed
-    } else { // report success
-        _Cnd_init_in_situ(cond);
-        *pcond = cond;
-        return _Thrd_success;
     }
+
+    _Cnd_init_in_situ(cond);
+    *pcond = cond;
+    return _Thrd_success;
 }
 
-void _Cnd_destroy(_Cnd_t cond) { // clean up
+void _Cnd_destroy(const _Cnd_t cond) { // clean up
     if (cond) { // something to do, do it
         _Cnd_destroy_in_situ(cond);
         _free_crt(cond);
     }
 }
 
-static int do_wait(_Cnd_t cond, _Mtx_t mtx, const xtime* target) { // wait for signal or timeout
-    int res = _Thrd_success;
-    auto cs = static_cast<Concurrency::details::stl_critical_section_interface*>(_Mtx_getconcrtcs(mtx));
-    if (target == 0) { // no target time specified, wait on mutex
+int _Cnd_wait(const _Cnd_t cond, const _Mtx_t mtx) { // wait until signaled
+    const auto cs = static_cast<Concurrency::details::stl_critical_section_interface*>(_Mtx_getconcrtcs(mtx));
+    _Mtx_clear_owner(mtx);
+    cond->_get_cv()->wait(cs);
+    _Mtx_reset_owner(mtx);
+    return _Thrd_success; // TRANSITION, ABI: Always returns _Thrd_success
+}
+
+int _Cnd_timedwait(const _Cnd_t cond, const _Mtx_t mtx, const xtime* const target) { // wait until signaled or timeout
+    int res       = _Thrd_success;
+    const auto cs = static_cast<Concurrency::details::stl_critical_section_interface*>(_Mtx_getconcrtcs(mtx));
+    if (target == nullptr) { // no target time specified, wait on mutex
         _Mtx_clear_owner(mtx);
         cond->_get_cv()->wait(cs);
         _Mtx_reset_owner(mtx);
@@ -74,30 +84,14 @@ static int do_wait(_Cnd_t cond, _Mtx_t mtx, const xtime* target) { // wait for s
     return res;
 }
 
-static int do_signal(_Cnd_t cond, int all) { // release threads
-    if (all) {
-        cond->_get_cv()->notify_all();
-    } else {
-        cond->_get_cv()->notify_one();
-    }
-
-    return _Thrd_success;
+int _Cnd_signal(const _Cnd_t cond) { // release one waiting thread
+    cond->_get_cv()->notify_one();
+    return _Thrd_success; // TRANSITION, ABI: Always returns _Thrd_success
 }
 
-int _Cnd_wait(_Cnd_t cond, _Mtx_t mtx) { // wait until signaled
-    return do_wait(cond, mtx, 0);
-}
-
-int _Cnd_timedwait(_Cnd_t cond, _Mtx_t mtx, const xtime* xt) { // wait until signaled or timeout
-    return do_wait(cond, mtx, xt);
-}
-
-int _Cnd_signal(_Cnd_t cond) { // release one waiting thread
-    return do_signal(cond, 0);
-}
-
-int _Cnd_broadcast(_Cnd_t cond) { // release all waiting threads
-    return do_signal(cond, 1);
+int _Cnd_broadcast(const _Cnd_t cond) { // release all waiting threads
+    cond->_get_cv()->notify_all();
+    return _Thrd_success; // TRANSITION, ABI: Always returns _Thrd_success
 }
 
 /*

--- a/stl/src/mutex.cpp
+++ b/stl/src/mutex.cpp
@@ -168,7 +168,7 @@ int _Mtx_unlock(_Mtx_t mtx) { // unlock mutex
         mtx->thread_id = -1;
         mtx->_get_cs()->unlock();
     }
-    return _Thrd_success;
+    return _Thrd_success; // TRANSITION, ABI: always returns _Thrd_success
 }
 
 int _Mtx_lock(_Mtx_t mtx) { // lock mutex

--- a/tests/libcxx/expected_results.txt
+++ b/tests/libcxx/expected_results.txt
@@ -540,7 +540,7 @@ std/containers/views/span.cons/ptr_ptr.pass.cpp:0 FAIL
 # LLVM-33230 "Clang on Windows should define __STDCPP_THREADS__ to be 1"
 std/thread/macro.pass.cpp:1 FAIL
 
-# Clang's tgmath.h interferes with the UCRT's tgmath.h
+# LLVM-46207 Clang's tgmath.h interferes with the UCRT's tgmath.h
 std/depr/depr.c.headers/tgmath_h.pass.cpp:1 FAIL
 
 

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -540,7 +540,7 @@ containers\views\span.cons\ptr_ptr.pass.cpp
 # LLVM-33230 "Clang on Windows should define __STDCPP_THREADS__ to be 1"
 thread\macro.pass.cpp
 
-# Clang's tgmath.h interferes with the UCRT's tgmath.h
+# LLVM-46207 Clang's tgmath.h interferes with the UCRT's tgmath.h
 depr\depr.c.headers\tgmath_h.pass.cpp
 
 

--- a/tests/std/include/range_algorithm_support.hpp
+++ b/tests/std/include/range_algorithm_support.hpp
@@ -47,387 +47,454 @@ struct borrowed { // borrowed<true> is a borrowed_range; borrowed<false> is not
 };
 
 template <>
-inline constexpr bool std::ranges::enable_borrowed_range<borrowed<true>> = true;
+inline constexpr bool ranges::enable_borrowed_range<borrowed<true>> = true;
 
-#ifndef __clang__ // TRANSITION, LLVM-45213
-inline
-#endif
-    constexpr auto get_first = [](auto&& x) -> auto&& {
-    return static_cast<decltype(x)>(x).first;
+struct boolish {
+    bool value_ = true;
+
+    constexpr operator bool() const noexcept {
+        return value_;
+    }
+
+    [[nodiscard]] constexpr boolish operator!() const noexcept {
+        return {!value_};
+    }
 };
 
-#ifndef __clang__ // TRANSITION, LLVM-45213
-inline
-#endif
-    constexpr auto get_second = [](auto&& x) -> auto&& {
-    return static_cast<decltype(x)>(x).second;
+namespace test {
+    using std::assignable_from, std::conditional_t, std::copy_constructible, std::derived_from, std::exchange,
+        std::ptrdiff_t, std::span;
+
+    using output     = std::output_iterator_tag;
+    using input      = std::input_iterator_tag;
+    using fwd        = std::forward_iterator_tag;
+    using bidi       = std::bidirectional_iterator_tag;
+    using random     = std::random_access_iterator_tag;
+    using contiguous = std::contiguous_iterator_tag;
+
+    template <class T>
+    void operator&(T&&) {
+        STATIC_ASSERT(always_false<T>);
+    }
+
+    template <class T, class U>
+    void operator,(T&&, U&&) {
+        STATIC_ASSERT(always_false<T>);
+    }
+
+    enum class CanDifference : bool { no, yes };
+    enum class CanCompare : bool { no, yes };
+    enum class ProxyRef : bool { no, yes };
+    enum class IsWrapped : bool { no, yes };
+
+    template <class Element, IsWrapped Wrapped = IsWrapped::yes>
+    class sentinel {
+        Element* ptr_ = nullptr;
+
+    public:
+        sentinel() = default;
+        constexpr explicit sentinel(Element* ptr) noexcept : ptr_{ptr} {}
+
+        [[nodiscard]] constexpr Element* base() const noexcept {
+            return ptr_;
+        }
+
+        using _Prevent_inheriting_unwrap = sentinel;
+
+        using unwrap = sentinel<Element, IsWrapped::no>;
+
+        [[nodiscard]] constexpr auto _Unwrapped() const noexcept requires(bool(Wrapped)) {
+            return unwrap{ptr_};
+        }
+
+        static constexpr bool _Unwrap_when_unverified = true;
+
+        constexpr void _Seek_to(unwrap const& s) noexcept requires(bool(Wrapped)) {
+            ptr_ = s.base();
+        }
+    };
+
+    template <class Category, class Element>
+    class proxy_reference {
+        Element& ref_;
+
+        using ValueType = std::remove_cv_t<Element>;
+
+    public:
+        constexpr explicit proxy_reference(Element& ref) : ref_{ref} {}
+        proxy_reference(proxy_reference const&) = default;
+
+        constexpr proxy_reference const& operator=(proxy_reference const& that) const
+            requires assignable_from<Element&, Element&> {
+            ref_ = that.ref_;
+            return *this;
+        }
+
+        // clang-format off
+        constexpr operator ValueType() const requires derived_from<Category, input> && copy_constructible<ValueType> {
+            return ref_;
+        }
+        // clang-format on
+
+        constexpr void operator=(ValueType const& val) const requires assignable_from<Element&, ValueType const&> {
+            ref_ = val;
+        }
+
+        constexpr Element& peek() const noexcept {
+            return ref_;
+        }
+    };
+
+    // clang-format off
+    template <class Cat1, class Elem1, class Cat2, class Elem2>
+    constexpr boolish operator==(proxy_reference<Cat1, Elem1> x, proxy_reference<Cat2, Elem2> y) requires requires {
+        { x.peek() == y.peek() } -> std::convertible_to<bool>;
+    } {
+        return {x.peek() == y.peek()};
+    }
+    template <class Cat1, class Elem1, class Cat2, class Elem2>
+    constexpr boolish operator!=(proxy_reference<Cat1, Elem1> x, proxy_reference<Cat2, Elem2> y) requires requires {
+        { x.peek() == y.peek() } -> std::convertible_to<bool>;
+    } {
+        return !(x == y);
+    }
+
+    template <class Category, class Element,
+        // Model sized_sentinel_for along with sentinel?
+        CanDifference Diff = CanDifference{derived_from<Category, random>},
+        // Model sentinel_for with self (and sized_sentinel_for if Diff; implies copyable)?
+        CanCompare Eq = CanCompare{derived_from<Category, fwd>},
+        // Use a ProxyRef reference type (instead of Element&)?
+        ProxyRef Proxy = ProxyRef{!derived_from<Category, contiguous>},
+        // Interact with the STL's iterator unwrapping machinery?
+        IsWrapped Wrapped = IsWrapped::yes>
+        requires (bool(Eq) || !derived_from<Category, fwd>)
+            && (!bool(Proxy) || !derived_from<Category, contiguous>)
+    class iterator {
+        Element* ptr_;
+
+        template <class T>
+        static constexpr bool at_least = derived_from<Category, T>;
+
+        using ReferenceType = conditional_t<bool(Proxy), proxy_reference<Category, Element>, Element&>;
+
+    public:
+        // output iterator operations
+        iterator() = default;
+
+        constexpr explicit iterator(Element* ptr) noexcept : ptr_{ptr} {}
+
+        constexpr iterator(iterator&& that) noexcept : ptr_{exchange(that.ptr_, nullptr)} {}
+        constexpr iterator& operator=(iterator&& that) noexcept {
+            ptr_ = exchange(that.ptr_, nullptr);
+            return *this;
+        }
+
+        [[nodiscard]] constexpr Element* base() const& noexcept requires (bool(Eq)) {
+            return ptr_;
+        }
+        [[nodiscard]] constexpr Element* base() && noexcept {
+            return exchange(ptr_, nullptr);
+        }
+
+        [[nodiscard]] constexpr ReferenceType operator*() const noexcept {
+            return ReferenceType{*ptr_};
+        }
+
+        [[nodiscard]] constexpr boolish operator==(sentinel<Element, Wrapped> const& s) const noexcept {
+            return boolish{ptr_ == s.base()};
+        }
+        [[nodiscard]] friend constexpr boolish operator==(
+            sentinel<Element, Wrapped> const& s, iterator const& i) noexcept {
+            return i == s;
+        }
+        [[nodiscard]] constexpr boolish operator!=(sentinel<Element, Wrapped> const& s) const noexcept {
+            return !(*this == s);
+        }
+        [[nodiscard]] friend constexpr boolish operator!=(
+            sentinel<Element, Wrapped> const& s, iterator const& i) noexcept {
+            return !(i == s);
+        }
+
+        constexpr iterator& operator++() & noexcept {
+            ++ptr_;
+            return *this;
+        }
+        constexpr iterator operator++(int) & noexcept {
+            auto tmp = *this;
+            ++ptr_;
+            return tmp;
+        }
+
+        auto operator--() & {
+            STATIC_ASSERT(always_false<Category>);
+        }
+        auto operator--(int) & {
+            STATIC_ASSERT(always_false<Category>);
+        }
+
+        friend void iter_swap(iterator const&, iterator const&) {
+            STATIC_ASSERT(always_false<Category>);
+        }
+
+        void operator<(iterator const&) const {
+            STATIC_ASSERT(always_false<Category>);
+        }
+        void operator>(iterator const&) const {
+            STATIC_ASSERT(always_false<Category>);
+        }
+        void operator<=(iterator const&) const {
+            STATIC_ASSERT(always_false<Category>);
+        }
+        void operator>=(iterator const&) const {
+            STATIC_ASSERT(always_false<Category>);
+        }
+
+        // input iterator operations:
+        constexpr void operator++(int) & noexcept requires std::is_same_v<Category, input> {
+            ++ptr_;
+        }
+
+        [[nodiscard]] constexpr friend std::remove_cv_t<Element> iter_move(iterator const& i) requires at_least<input> {
+            return ranges::iter_move(i.ptr_);
+        }
+
+        constexpr friend void iter_swap(iterator const& x, iterator const& y) requires at_least<input> {
+            ranges::iter_swap(x.ptr_, y.ptr_);
+        }
+
+        // sentinel operations (implied by forward iterator):
+        iterator(iterator const&) requires (bool(Eq)) = default;
+        iterator& operator=(iterator const&) requires (bool(Eq)) = default;
+        [[nodiscard]] constexpr boolish operator==(iterator const& that) const noexcept requires (bool(Eq)) {
+            return {ptr_ == that.ptr_};
+        }
+        [[nodiscard]] constexpr boolish operator!=(iterator const& that) const noexcept requires (bool(Eq)) {
+            return !(*this == that);
+        }
+
+        // bidi iterator operations:
+        constexpr iterator& operator--() & noexcept requires at_least<bidi> {
+            --ptr_;
+            return *this;
+        }
+        constexpr iterator operator--(int) & noexcept requires at_least<bidi> {
+            auto tmp = *this;
+            --ptr_;
+            return tmp;
+        }
+
+        // random-access iterator operations:
+        [[nodiscard]] constexpr boolish operator<(iterator const& that) const noexcept requires at_least<random> {
+            return {ptr_ < that.ptr_};
+        }
+        [[nodiscard]] constexpr boolish operator>(iterator const& that) const noexcept requires at_least<random> {
+            return that < *this;
+        }
+        [[nodiscard]] constexpr boolish operator<=(iterator const& that) const noexcept requires at_least<random> {
+            return !(that < *this);
+        }
+        [[nodiscard]] constexpr boolish operator>=(iterator const& that) const noexcept requires at_least<random> {
+            return !(*this < that);
+        }
+        [[nodiscard]] constexpr ReferenceType operator[](ptrdiff_t const n) const& noexcept requires at_least<random> {
+            return ReferenceType{ptr_[n]};
+        }
+        constexpr iterator& operator+=(ptrdiff_t const n) & noexcept requires at_least<random> {
+            ptr_ += n;
+            return *this;
+        }
+        constexpr iterator& operator-=(ptrdiff_t const n) & noexcept requires at_least<random> {
+            ptr_ -= n;
+            return *this;
+        }
+        [[nodiscard]] constexpr iterator operator+(ptrdiff_t const n) const noexcept requires at_least<random> {
+            return iterator{ptr_ + n};
+        }
+        [[nodiscard]] friend constexpr iterator operator+(ptrdiff_t const n, iterator const& i) noexcept
+            requires at_least<random> {
+            return i + n;
+        }
+        [[nodiscard]] constexpr iterator operator-(ptrdiff_t const n) const noexcept requires at_least<random> {
+            return iterator{ptr_ - n};
+        }
+
+        // contiguous iterator operations:
+        [[nodiscard]] constexpr Element* operator->() const noexcept requires at_least<contiguous> {
+            return ptr_;
+        }
+
+        // sized_sentinel_for operations:
+        [[nodiscard]] constexpr ptrdiff_t operator-(iterator const& that) const noexcept
+            requires (bool(Diff) && bool(Eq)) || at_least<random> {
+            return ptr_ - that.ptr_;
+        }
+        [[nodiscard]] constexpr ptrdiff_t operator-(sentinel<Element, Wrapped> const& s) const noexcept
+            requires (bool(Diff)) {
+            return ptr_ - s.base();
+        }
+        [[nodiscard]] friend constexpr ptrdiff_t operator-(
+            sentinel<Element, Wrapped> const& s, iterator const& i) noexcept requires (bool(Diff)) {
+            return -(i - s);
+        }
+
+        // iterator unwrapping operations:
+        using _Prevent_inheriting_unwrap = iterator;
+
+        using unwrap = iterator<Category, Element, Diff, Eq, Proxy, IsWrapped::no>;
+
+        [[nodiscard]] constexpr auto _Unwrapped() const& noexcept requires (bool(Wrapped) && bool(Eq)) {
+            return unwrap{ptr_};
+        }
+
+        [[nodiscard]] constexpr auto _Unwrapped() && noexcept requires (bool(Wrapped)) {
+            return unwrap{exchange(ptr_, nullptr)};
+        }
+
+        static constexpr bool _Unwrap_when_unverified = true;
+
+        constexpr void _Seek_to(unwrap const& i) noexcept requires (bool(Wrapped) && bool(Eq)) {
+            ptr_ = i.base();
+        }
+
+        constexpr void _Seek_to(unwrap&& i) noexcept requires (bool(Wrapped)) {
+            ptr_ = std::move(i).base();
+        }
+    };
+    // clang-format on
+} // namespace test
+
+template <class Category, class Element, ::test::CanDifference Diff, ::test::CanCompare Eq, ::test::ProxyRef Proxy,
+    ::test::IsWrapped Wrapped>
+struct std::iterator_traits<::test::iterator<Category, Element, Diff, Eq, Proxy, Wrapped>> {
+    using iterator_concept  = Category;
+    using iterator_category = conditional_t<derived_from<Category, forward_iterator_tag>, //
+        conditional_t<bool(Proxy), input_iterator_tag, Category>, //
+        conditional_t<bool(Eq), Category, void>>; // TRANSITION, LWG-3289
+    using value_type        = remove_cv_t<Element>;
+    using difference_type   = ptrdiff_t;
+    using pointer           = conditional_t<derived_from<Category, contiguous_iterator_tag>, Element*, void>;
+    using reference         = iter_reference_t<::test::iterator<Category, Element, Diff, Eq, Proxy, Wrapped>>;
 };
+
+template <class Element, ::test::CanDifference Diff, ::test::IsWrapped Wrapped>
+struct std::pointer_traits<::test::iterator<std::contiguous_iterator_tag, Element, Diff, ::test::CanCompare::yes,
+    ::test::ProxyRef::no, Wrapped>> {
+    using pointer         = ::test::iterator<contiguous_iterator_tag, Element, Diff, ::test::CanCompare::yes,
+        ::test::ProxyRef::no, Wrapped>;
+    using element_type    = Element;
+    using difference_type = ptrdiff_t;
+
+    [[nodiscard]] static constexpr element_type* to_address(pointer const& x) noexcept {
+        return x.base();
+    }
+};
+
+namespace test {
+    enum class Sized : bool { no, yes };
+    enum class Common : bool { no, yes };
+
+    // clang-format off
+    template <class Category, class Element,
+        // Implement member size? (NB: Not equivalent to "Is this a sized_range?")
+        Sized IsSized = Sized::no,
+        // iterator and sentinel model sized_sentinel_for (also iterator and iterator if Eq)
+        CanDifference Diff = CanDifference{derived_from<Category, random>},
+        // Model common_range?
+        Common IsCommon = Common::no,
+        // Iterator models sentinel_for with self
+        CanCompare Eq = CanCompare{derived_from<Category, fwd>},
+        // Use a ProxyRef reference type?
+        ProxyRef Proxy = ProxyRef{!derived_from<Category, contiguous>}>
+        requires (!bool(IsCommon) || bool(Eq))
+            && (bool(Eq) || !derived_from<Category, fwd>)
+            && (!bool(Proxy) || !derived_from<Category, contiguous>)
+    class range : ranges::view_base {
+        span<Element> elements_;
+        mutable bool begin_called_ = false;
+
+    public:
+        using I = iterator<Category, Element, Diff, Eq, Proxy, IsWrapped::yes>;
+        using S = conditional_t<bool(IsCommon), I, sentinel<Element, IsWrapped::yes>>;
+
+        range() = default;
+        constexpr explicit range(span<Element> elements) noexcept : elements_{elements} {}
+
+        range(const range&) requires derived_from<Category, fwd> = default;
+        range& operator=(const range&) requires derived_from<Category, fwd> = default;
+
+        constexpr range(range&& that) noexcept
+            : elements_{exchange(that.elements_, {})}, begin_called_{that.begin_called_} {}
+
+        constexpr range& operator=(range&& that) noexcept {
+            elements_     = exchange(that.elements_, {});
+            begin_called_ = that.begin_called_;
+            return *this;
+        }
+
+        [[nodiscard]] constexpr I begin() const noexcept {
+            if constexpr (!derived_from<Category, fwd>) {
+                assert(!exchange(begin_called_, true));
+            }
+            return I{elements_.data()};
+        }
+
+        [[nodiscard]] constexpr S end() const noexcept {
+            return S{elements_.data() + elements_.size()};
+        }
+
+        [[nodiscard]] constexpr ptrdiff_t size() const noexcept requires (bool(IsSized)) {
+            if constexpr (!derived_from<Category, fwd>) {
+                assert(!begin_called_);
+            }
+            return static_cast<ptrdiff_t>(elements_.size());
+        }
+
+        [[nodiscard]] constexpr Element* data() const noexcept requires derived_from<Category, contiguous> {
+            return elements_.data();
+        }
+
+        using UI = iterator<Category, Element, Diff, Eq, Proxy, IsWrapped::no>;
+        using US = conditional_t<bool(IsCommon), I, sentinel<Element, IsWrapped::no>>;
+
+        [[nodiscard]] constexpr UI _Unchecked_begin() const noexcept {
+            return UI{elements_.data()};
+        }
+        [[nodiscard]] constexpr US _Unchecked_end() const noexcept {
+            return US{elements_.data() + elements_.size()};
+        }
+
+        void operator&() const {
+            STATIC_ASSERT(always_false<Category>);
+        }
+        template <class T>
+        friend void operator,(range const&, T&&) {
+            STATIC_ASSERT(always_false<Category>);
+        }
+    };
+    // clang-format on
+} // namespace test
 
 template <class T>
-class move_only_range : public ranges::view_base {
-    // Adapts a contiguous range into a move-only view with move-only iterators
-private:
-    using U = std::span<T>;
-    U elements;
-    mutable bool begin_called = false;
-
-    class iterator;
-    class sentinel;
-
+class move_only_range : public test::range<test::input, T, test::Sized::no, test::CanDifference::no, test::Common::no,
+                            test::CanCompare::no, test::ProxyRef::no> {
+#if defined(__clang__) || defined(__EDG__) // TRANSITION, VSO-1132704
+    using test::range<test::input, T, test::Sized::no, test::CanDifference::no, test::Common::no, test::CanCompare::no,
+        test::ProxyRef::no>::range;
+#else // ^^^ no workaround / workaround vvv
 public:
-    constexpr explicit move_only_range(U x) : elements{x} {}
-
-    constexpr move_only_range(move_only_range&& that)
-        : elements{std::exchange(that.elements, {})}, begin_called{that.begin_called} {}
-
-    constexpr move_only_range& operator=(move_only_range&& that) {
-        elements     = std::exchange(that.elements, {});
-        begin_called = that.begin_called;
-        return *this;
-    }
-
-    constexpr iterator begin() const {
-        assert(!std::exchange(begin_called, true));
-        return iterator{elements.begin()};
-    }
-
-    constexpr sentinel end() const {
-        return sentinel{elements.end()};
-    }
+    constexpr move_only_range() = default;
+    constexpr explicit move_only_range(std::span<T> elements) noexcept : move_only_range::range{elements} {}
+    constexpr move_only_range(move_only_range&&) = default;
+    constexpr move_only_range& operator=(move_only_range&&) = default;
+#endif // TRANSITION, VSO-1132704
 };
 
 template <ranges::contiguous_range R>
 move_only_range(R&) -> move_only_range<std::remove_reference_t<ranges::range_reference_t<R>>>;
 
 template <class T>
-class move_only_range<T>::iterator {
-private:
-    friend sentinel;
-    ranges::iterator_t<std::span<T>> pos;
-
-public:
-    using iterator_concept  = std::input_iterator_tag;
-    using iterator_category = void; // TRANSITION, LWG-3289
-    using value_type        = std::remove_cv_t<T>;
-    using difference_type   = std::ptrdiff_t;
-    using pointer           = void;
-    using reference         = T&;
-
-    iterator() = default;
-    constexpr explicit iterator(ranges::iterator_t<U> p) : pos{p} {}
-    constexpr iterator(iterator&& that) : pos{std::exchange(that.pos, {})} {}
-
-    constexpr iterator& operator=(iterator&& that) {
-        pos = std::exchange(that.pos, {});
-        return *this;
-    }
-
-    constexpr ranges::iterator_t<U> base() const {
-        return pos;
-    }
-
-    constexpr T& operator*() const {
-        return *pos;
-    }
-    constexpr iterator& operator++() {
-        ++pos;
-        return *this;
-    }
-    constexpr void operator++(int) {
-        ++pos;
-    }
-};
-
-template <class T>
-class move_only_range<T>::sentinel {
-private:
-    ranges::iterator_t<U> pos;
-
-public:
-    sentinel() = default;
-    constexpr explicit sentinel(ranges::iterator_t<U> p) : pos{p} {}
-
-    constexpr ranges::iterator_t<U> base() const {
-        return pos;
-    }
-
-    constexpr bool operator==(iterator const& that) const {
-        return pos == that.pos;
-    }
-};
-
-template <class T>
 inline constexpr bool ranges::enable_borrowed_range<::move_only_range<T>> = true;
-
-struct boolish {
-    operator bool() const {
-        return true;
-    }
-
-    boolish operator!() const {
-        return *this;
-    }
-};
-
-template <class Category, class ValueType, bool Sized = false>
-struct test_iterator {
-    template <class T>
-    static constexpr bool exactly = std::is_same_v<T, Category>;
-    template <class T>
-    static constexpr bool at_least = std::derived_from<Category, T>;
-
-    struct reference {
-        operator ValueType() const requires at_least<std::input_iterator_tag> {
-            return {};
-        }
-        void operator=(ValueType const&) const {}
-    };
-
-    // output iterator operations
-    test_iterator()                = default;
-    test_iterator(test_iterator&&) = default;
-    test_iterator& operator=(test_iterator&&) = default;
-
-    reference operator*() const {
-        return {};
-    }
-    ValueType& operator*() const requires at_least<std::contiguous_iterator_tag> {
-        static ValueType value{};
-        return value;
-    }
-
-    friend boolish operator==(test_iterator const&, std::default_sentinel_t const&) {
-        return {};
-    }
-    friend boolish operator==(std::default_sentinel_t const&, test_iterator const&) {
-        return {};
-    }
-    friend boolish operator!=(test_iterator const&, std::default_sentinel_t const&) {
-        return {};
-    }
-    friend boolish operator!=(std::default_sentinel_t const&, test_iterator const&) {
-        return {};
-    }
-
-    test_iterator& operator++() & {
-        return *this;
-    }
-    test_iterator operator++(int) & {
-        return {};
-    }
-
-    auto operator--() & {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    auto operator--(int) & {
-        STATIC_ASSERT(always_false<Category>);
-    }
-
-    friend void iter_swap(test_iterator const&, test_iterator const&) {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    void operator<(test_iterator const&) const {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    void operator>(test_iterator const&) const {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    void operator<=(test_iterator const&) const {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    void operator>=(test_iterator const&) const {
-        STATIC_ASSERT(always_false<Category>);
-    }
-
-    void operator&() const {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    template <class T>
-    friend void operator,(test_iterator const&, T&&) {
-        STATIC_ASSERT(always_false<Category>);
-    }
-
-    // input iterator operations:
-    void operator++(int) & requires exactly<std::input_iterator_tag> {}
-    friend ValueType iter_move(test_iterator const&) requires at_least<std::input_iterator_tag> {
-        return {};
-    }
-    friend void iter_swap(test_iterator const&, test_iterator const&) requires at_least<std::input_iterator_tag> {}
-
-    // forward iterator operations:
-    test_iterator(test_iterator const&) requires at_least<std::forward_iterator_tag> = default;
-    test_iterator& operator=(test_iterator const&) requires at_least<std::forward_iterator_tag> = default;
-    test_iterator operator++(int) & requires at_least<std::forward_iterator_tag> {}
-    boolish operator==(test_iterator const&) const requires at_least<std::forward_iterator_tag> {
-        return {};
-    }
-    boolish operator!=(test_iterator const&) const requires at_least<std::forward_iterator_tag> {
-        return {};
-    }
-
-    // bidirectional iterator operations:
-    test_iterator& operator--() & requires at_least<std::bidirectional_iterator_tag> {
-        return *this;
-    }
-    test_iterator operator--(int) & requires at_least<std::bidirectional_iterator_tag> {}
-
-    // random-access iterator operations:
-    boolish operator<(test_iterator const&) const requires at_least<std::random_access_iterator_tag> {
-        return {};
-    }
-    boolish operator>(test_iterator const&) const requires at_least<std::random_access_iterator_tag> {
-        return {};
-    }
-    boolish operator<=(test_iterator const&) const requires at_least<std::random_access_iterator_tag> {
-        return {};
-    }
-    boolish operator>=(test_iterator const&) const requires at_least<std::random_access_iterator_tag> {
-        return {};
-    }
-    decltype(auto) operator[](std::ptrdiff_t) const& requires at_least<std::random_access_iterator_tag> {
-        return **this;
-    }
-    test_iterator& operator+=(std::ptrdiff_t) & requires at_least<std::random_access_iterator_tag> {
-        return *this;
-    }
-    test_iterator& operator-=(std::ptrdiff_t) & requires at_least<std::random_access_iterator_tag> {
-        return *this;
-    }
-    test_iterator operator+(std::ptrdiff_t) const requires at_least<std::random_access_iterator_tag> {
-        return *this;
-    }
-    friend test_iterator operator+(
-        std::ptrdiff_t, test_iterator const& i) requires at_least<std::random_access_iterator_tag> {
-        return i;
-    }
-    test_iterator operator-(std::ptrdiff_t) const requires at_least<std::random_access_iterator_tag> {
-        return *this;
-    }
-
-    // sized_sentinel_for operations:
-    std::ptrdiff_t operator-(test_iterator const&) const requires Sized || at_least<std::random_access_iterator_tag> {
-        return 42;
-    }
-    friend std::ptrdiff_t operator-(std::default_sentinel_t, test_iterator const&) requires Sized {
-        return 42;
-    }
-    friend std::ptrdiff_t operator-(test_iterator const&, std::default_sentinel_t) requires Sized {
-        return -42;
-    }
-};
-
-template <class Category, class ValueType, bool Sized>
-struct std::iterator_traits<::test_iterator<Category, ValueType, Sized>> {
-    using iterator_concept  = Category;
-    using iterator_category = Category; // TRANSITION, LWG-3289
-    using value_type        = ValueType;
-    using difference_type   = ptrdiff_t;
-    using pointer           = void;
-    using reference         = iter_reference_t<::test_iterator<Category, ValueType, Sized>>;
-};
-
-template <class ValueType, bool Sized>
-struct std::pointer_traits<::test_iterator<std::contiguous_iterator_tag, ValueType, Sized>> {
-    using pointer         = ::test_iterator<contiguous_iterator_tag, ValueType, Sized>;
-    using element_type    = ValueType;
-    using difference_type = ptrdiff_t;
-
-    [[nodiscard]] static constexpr element_type* to_address(pointer) noexcept {
-        return nullptr;
-    }
-};
-
-STATIC_ASSERT(std::output_iterator<test_iterator<std::output_iterator_tag, int, false>, int>);
-STATIC_ASSERT(std::input_iterator<test_iterator<std::input_iterator_tag, int, false>>);
-STATIC_ASSERT(std::forward_iterator<test_iterator<std::forward_iterator_tag, int, false>>);
-STATIC_ASSERT(std::bidirectional_iterator<test_iterator<std::bidirectional_iterator_tag, int, false>>);
-STATIC_ASSERT(std::random_access_iterator<test_iterator<std::random_access_iterator_tag, int, false>>);
-STATIC_ASSERT(std::contiguous_iterator<test_iterator<std::contiguous_iterator_tag, int, false>>);
-
-STATIC_ASSERT(std::output_iterator<test_iterator<std::output_iterator_tag, int, true>, int>);
-STATIC_ASSERT(std::input_iterator<test_iterator<std::input_iterator_tag, int, true>>);
-STATIC_ASSERT(std::forward_iterator<test_iterator<std::forward_iterator_tag, int, true>>);
-STATIC_ASSERT(std::bidirectional_iterator<test_iterator<std::bidirectional_iterator_tag, int, true>>);
-STATIC_ASSERT(std::random_access_iterator<test_iterator<std::random_access_iterator_tag, int, true>>);
-STATIC_ASSERT(std::contiguous_iterator<test_iterator<std::contiguous_iterator_tag, int, true>>);
-
-STATIC_ASSERT(std::sized_sentinel_for<std::default_sentinel_t, test_iterator<std::output_iterator_tag, int, true>>);
-STATIC_ASSERT(std::sized_sentinel_for<std::default_sentinel_t, test_iterator<std::input_iterator_tag, int, true>>);
-STATIC_ASSERT(std::sized_sentinel_for<std::default_sentinel_t, test_iterator<std::forward_iterator_tag, int, true>>);
-STATIC_ASSERT(
-    std::sized_sentinel_for<std::default_sentinel_t, test_iterator<std::bidirectional_iterator_tag, int, true>>);
-STATIC_ASSERT(
-    std::sized_sentinel_for<std::default_sentinel_t, test_iterator<std::random_access_iterator_tag, int, true>>);
-STATIC_ASSERT(std::sized_sentinel_for<std::default_sentinel_t, test_iterator<std::contiguous_iterator_tag, int, true>>);
-
-STATIC_ASSERT(std::sized_sentinel_for<test_iterator<std::forward_iterator_tag, int, true>,
-    test_iterator<std::forward_iterator_tag, int, true>>);
-STATIC_ASSERT(std::sized_sentinel_for<test_iterator<std::bidirectional_iterator_tag, int, true>,
-    test_iterator<std::bidirectional_iterator_tag, int, true>>);
-STATIC_ASSERT(std::sized_sentinel_for<test_iterator<std::random_access_iterator_tag, int, true>,
-    test_iterator<std::random_access_iterator_tag, int, true>>);
-STATIC_ASSERT(std::sized_sentinel_for<test_iterator<std::contiguous_iterator_tag, int, true>,
-    test_iterator<std::contiguous_iterator_tag, int, true>>);
-
-template <class Category, class ValueType, bool Sized = false, bool Common = false>
-struct test_range {
-    using I = test_iterator<Category, ValueType, Sized>;
-    using S = std::conditional_t<Common && std::derived_from<Category, std::forward_iterator_tag>, I,
-        std::default_sentinel_t>;
-
-    I begin() const {
-        return {};
-    }
-
-    S end() const {
-        return {};
-    }
-
-    std::ptrdiff_t size() const requires Sized {
-        return 42;
-    }
-
-    ValueType* data() const requires std::derived_from<Category, std::contiguous_iterator_tag> {
-        return nullptr;
-    }
-
-    void operator&() const {
-        STATIC_ASSERT(always_false<Category>);
-    }
-    template <class T>
-    friend void operator,(test_range const&, T&&) {
-        STATIC_ASSERT(always_false<Category>);
-    }
-};
-
-STATIC_ASSERT(ranges::output_range<test_range<std::output_iterator_tag, int, false>, int>);
-STATIC_ASSERT(ranges::input_range<test_range<std::input_iterator_tag, int, false>>);
-STATIC_ASSERT(ranges::forward_range<test_range<std::forward_iterator_tag, int, false>>);
-STATIC_ASSERT(ranges::bidirectional_range<test_range<std::bidirectional_iterator_tag, int, false>>);
-STATIC_ASSERT(ranges::random_access_range<test_range<std::random_access_iterator_tag, int, false>>);
-STATIC_ASSERT(ranges::contiguous_range<test_range<std::contiguous_iterator_tag, int, false>>);
-
-STATIC_ASSERT(ranges::output_range<test_range<std::output_iterator_tag, int, true>, int>);
-STATIC_ASSERT(ranges::input_range<test_range<std::input_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::forward_range<test_range<std::forward_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::bidirectional_range<test_range<std::bidirectional_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::random_access_range<test_range<std::random_access_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::contiguous_range<test_range<std::contiguous_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::output_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::input_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::forward_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::bidirectional_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::random_access_iterator_tag, int, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::contiguous_iterator_tag, int, true>>);
-
-STATIC_ASSERT(ranges::forward_range<test_range<std::forward_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::bidirectional_range<test_range<std::bidirectional_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::random_access_range<test_range<std::random_access_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::contiguous_range<test_range<std::contiguous_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::forward_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::bidirectional_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::random_access_iterator_tag, int, true, true>>);
-STATIC_ASSERT(ranges::sized_range<test_range<std::contiguous_iterator_tag, int, true, true>>);
 
 template <int>
 struct unique_tag {};
@@ -448,126 +515,376 @@ using ProjectedBinaryPredicate = boolish (*)(unique_tag<Tag1>, unique_tag<Tag2>)
 template <class I1, class I2>
 using BinaryPredicateFor = boolish (*)(std::iter_common_reference_t<I1>, std::iter_common_reference_t<I2>);
 
-template <class Continuation>
-struct with_output_iterators {
+template <class Continuation, class Element = int>
+struct with_writable_iterators {
     template <class... Args>
-    static void call() {
-        Continuation::template call<Args..., test_iterator<std::output_iterator_tag, int>>();
-        Continuation::template call<Args..., test_iterator<std::input_iterator_tag, int>>();
-        Continuation::template call<Args..., test_iterator<std::forward_iterator_tag, int, false>>();
-        Continuation::template call<Args..., test_iterator<std::forward_iterator_tag, int, true>>();
-        Continuation::template call<Args..., test_iterator<std::bidirectional_iterator_tag, int, false>>();
-        Continuation::template call<Args..., test_iterator<std::bidirectional_iterator_tag, int, true>>();
-        Continuation::template call<Args..., test_iterator<std::random_access_iterator_tag, int>>();
-        Continuation::template call<Args..., test_iterator<std::contiguous_iterator_tag, int>>();
+    static constexpr void call() {
+        using namespace test;
+
+        // Diff and Eq are not significant for "lone" single-pass iterators, so we can ignore them here.
+        Continuation::template call<Args...,
+            iterator<output, Element, CanDifference::no, CanCompare::no, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<output, Element, CanDifference::no, CanCompare::no, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            iterator<input, Element, CanDifference::no, CanCompare::no, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<input, Element, CanDifference::no, CanCompare::no, ProxyRef::yes>>();
+        // For forward and bidi, Eq is necessarily true but Diff and Proxy may vary.
+        Continuation::template call<Args...,
+            iterator<fwd, Element, CanDifference::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<fwd, Element, CanDifference::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            iterator<fwd, Element, CanDifference::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<fwd, Element, CanDifference::yes, CanCompare::yes, ProxyRef::yes>>();
+
+        Continuation::template call<Args...,
+            iterator<bidi, Element, CanDifference::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<bidi, Element, CanDifference::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            iterator<bidi, Element, CanDifference::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<bidi, Element, CanDifference::yes, CanCompare::yes, ProxyRef::yes>>();
+        // Random iterators are Diff and Eq - only Proxy varies.
+        Continuation::template call<Args...,
+            iterator<random, Element, CanDifference::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<random, Element, CanDifference::yes, CanCompare::yes, ProxyRef::yes>>();
+        // Contiguous iterators are totally locked down.
+        Continuation::template call<Args..., iterator<contiguous, Element>>();
     }
 };
 
-template <class Continuation>
+template <class Continuation, class Element = int>
 struct with_input_ranges {
     template <class... Args>
-    static void call() {
-        Continuation::template call<Args..., test_range<std::input_iterator_tag, int, false>>();
-        Continuation::template call<Args..., test_range<std::input_iterator_tag, int, true>>();
+    static constexpr void call() {
+        using namespace test;
 
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, false, false>>();
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, false, true>>();
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, true, true>>();
+        // For all ranges, IsCommon implies Eq.
+        // For single-pass ranges, Eq is uninteresting without IsCommon (there's only one valid iterator
+        // value at a time, and no reason to compare it with itself for equality).
+        Continuation::template call<Args...,
+            range<input, Element, Sized::no, CanDifference::no, Common::no, CanCompare::no, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::no, CanDifference::no, Common::no, CanCompare::no, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>>();
 
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, false, false>>();
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, false, true>>();
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, true, true>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::no, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::no, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>>();
 
-        Continuation::template call<Args..., test_range<std::random_access_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::random_access_iterator_tag, int, true, true>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::no, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::no, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>>();
 
-        Continuation::template call<Args..., test_range<std::contiguous_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::contiguous_iterator_tag, int, true, true>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<input, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+
+        // forward always has Eq; !IsSized && Diff is uninteresting (sized_range is sized_range).
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+
+        // Ditto always Eq; !IsSized && Diff is uninteresting (ranges::size still works).
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+
+        // Ditto always Eq; !IsSized && SizedSentinel is uninteresting (ranges::size works either way), as is
+        // !IsSized && IsCommon.
+        Continuation::template call<Args...,
+            range<random, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+
+        // Ditto always Eq; !IsSized && SizedSentinel is uninteresting (ranges::size still works), as is
+        // !IsSized && IsCommon. contiguous also implies !Proxy.
+        Continuation::template call<Args...,
+            range<contiguous, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<contiguous, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<contiguous, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<contiguous, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<contiguous, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>>();
     }
 };
 
-template <class Continuation>
+template <class Continuation, class Element = int>
 struct with_forward_ranges {
     template <class... Args>
-    static void call() {
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, false, false>>();
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, false, true>>();
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::forward_iterator_tag, int, true, true>>();
+    static constexpr void call() {
+        using namespace test;
 
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, false, false>>();
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, false, true>>();
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::bidirectional_iterator_tag, int, true, true>>();
+        // forward always has Eq; !IsSized && Diff is uninteresting (sized_range is sized_range).
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<fwd, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>>();
 
-        Continuation::template call<Args..., test_range<std::random_access_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::random_access_iterator_tag, int, true, true>>();
+        // Ditto always Eq; !IsSized && Diff is uninteresting (ranges::size still works).
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<bidi, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>>();
 
-        Continuation::template call<Args..., test_range<std::contiguous_iterator_tag, int, true, false>>();
-        Continuation::template call<Args..., test_range<std::contiguous_iterator_tag, int, true, true>>();
+        // Ditto always Eq; !IsSized && SizedSentinel is uninteresting (ranges::size works either way), as is
+        // !IsSized && IsCommon.
+        Continuation::template call<Args...,
+            range<random, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<random, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>>();
+
+        // Ditto always Eq; !IsSized && SizedSentinel is uninteresting (ranges::size still works), as is
+        // !IsSized && IsCommon. contiguous also implies !Proxy.
+        Continuation::template call<Args...,
+            range<contiguous, Element, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<contiguous, Element, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<contiguous, Element, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<contiguous, Element, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            range<contiguous, Element, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>>();
     }
 };
 
-template <class Continuation>
+template <class Continuation, class Element = int>
 struct with_input_iterators {
     template <class... Args>
-    static void call() {
-        Continuation::template call<Args..., test_iterator<std::input_iterator_tag, int>>();
-        Continuation::template call<Args..., test_iterator<std::forward_iterator_tag, int, false>>();
-        Continuation::template call<Args..., test_iterator<std::forward_iterator_tag, int, true>>();
-        Continuation::template call<Args..., test_iterator<std::bidirectional_iterator_tag, int, false>>();
-        Continuation::template call<Args..., test_iterator<std::bidirectional_iterator_tag, int, true>>();
-        Continuation::template call<Args..., test_iterator<std::random_access_iterator_tag, int>>();
-        Continuation::template call<Args..., test_iterator<std::contiguous_iterator_tag, int>>();
+    static constexpr void call() {
+        using namespace test;
+
+        // IsSized and Eq are not significant for "lone" single-pass iterators, so we can ignore them here.
+        Continuation::template call<Args...,
+            iterator<input, Element, CanDifference::no, CanCompare::no, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<input, Element, CanDifference::no, CanCompare::no, ProxyRef::yes>>();
+        // For forward and bidi, Eq is necessarily true but IsSized and Proxy may vary.
+        Continuation::template call<Args...,
+            iterator<fwd, Element, CanDifference::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<fwd, Element, CanDifference::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            iterator<fwd, Element, CanDifference::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<fwd, Element, CanDifference::yes, CanCompare::yes, ProxyRef::yes>>();
+
+        Continuation::template call<Args...,
+            iterator<bidi, Element, CanDifference::no, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<bidi, Element, CanDifference::no, CanCompare::yes, ProxyRef::yes>>();
+        Continuation::template call<Args...,
+            iterator<bidi, Element, CanDifference::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<bidi, Element, CanDifference::yes, CanCompare::yes, ProxyRef::yes>>();
+        // Random iterators are IsSized and Eq - only Proxy varies.
+        Continuation::template call<Args...,
+            iterator<random, Element, CanDifference::yes, CanCompare::yes, ProxyRef::no>>();
+        Continuation::template call<Args...,
+            iterator<random, Element, CanDifference::yes, CanCompare::yes, ProxyRef::yes>>();
+        // Contiguous iterators are totally locked down.
+        Continuation::template call<Args..., iterator<contiguous, Element>>();
     }
 };
 
 template <class Continuation>
 struct with_difference {
     template <class Iterator>
-    static void call() {
+    static constexpr void call() {
         Continuation::template call<Iterator, std::iter_difference_t<Iterator>>();
     }
 };
 
-template <class Instantiator>
-void test_out() {
-    with_output_iterators<Instantiator>::call();
+template <class Instantiator, class Element = int>
+constexpr void test_in() {
+    with_input_ranges<Instantiator, Element>::call();
 }
 
-template <class Instantiator>
-void test_in() {
-    with_input_ranges<Instantiator>::call();
+template <class Instantiator, class Element = int>
+constexpr void test_fwd() {
+    with_forward_ranges<Instantiator, Element>::call();
 }
 
-template <class Instantiator>
-void test_fwd() {
-    with_forward_ranges<Instantiator>::call();
+template <class Instantiator, class Element1 = int, class Element2 = int>
+constexpr void test_in_in() {
+    with_input_ranges<with_input_ranges<Instantiator, Element2>, Element1>::call();
 }
 
-template <class Instantiator>
-void test_in_in() {
-    with_input_ranges<with_input_ranges<Instantiator>>::call();
+template <class Instantiator, class Element1 = int, class Element2 = int>
+constexpr void test_in_fwd() {
+    with_input_ranges<with_forward_ranges<Instantiator, Element2>, Element1>::call();
 }
 
-template <class Instantiator>
-void test_in_fwd() {
-    with_input_ranges<with_forward_ranges<Instantiator>>::call();
+template <class Instantiator, class Element1 = int, class Element2 = int>
+constexpr void test_fwd_fwd() {
+    with_forward_ranges<with_forward_ranges<Instantiator, Element2>, Element1>::call();
 }
 
-template <class Instantiator>
-void test_fwd_fwd() {
-    with_forward_ranges<with_forward_ranges<Instantiator>>::call();
+template <class Instantiator, class Element1 = int, class Element2 = int>
+constexpr void test_in_write() {
+    with_input_ranges<with_writable_iterators<Instantiator, Element2>, Element1>::call();
 }
 
-template <class Instantiator>
-void test_in_out() {
-    with_input_ranges<with_output_iterators<Instantiator>>::call();
+template <class Instantiator, class Element1 = int, class Element2 = int>
+constexpr void test_counted_write() {
+    with_input_iterators<with_difference<with_writable_iterators<Instantiator, Element2>>, Element1>::call();
 }
 
-template <class Instantiator>
-void test_counted_out() {
-    with_input_iterators<with_difference<with_output_iterators<Instantiator>>>::call();
-}
+template <size_t I>
+struct get_nth_fn {
+    template <class T>
+    [[nodiscard]] constexpr auto&& operator()(T&& t) const noexcept requires requires {
+        get<I>(std::forward<T>(t));
+    }
+    { return get<I>(std::forward<T>(t)); }
+
+    template <class T, class Elem>
+    [[nodiscard]] constexpr decltype(auto) operator()(test::proxy_reference<T, Elem> ref) const noexcept
+        requires requires {
+        (*this)(ref.peek());
+    }
+    { return (*this)(ref.peek()); }
+};
+inline constexpr get_nth_fn<0> get_first;
+inline constexpr get_nth_fn<1> get_second;

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -254,6 +254,7 @@ tests\P0896R4_ranges_alg_none_of
 tests\P0896R4_ranges_iterator_machinery
 tests\P0896R4_ranges_range_machinery
 tests\P0896R4_ranges_subrange
+tests\P0896R4_ranges_test_machinery
 tests\P0896R4_ranges_to_address
 tests\P0898R3_concepts
 tests\P0898R3_identity

--- a/tests/std/test.lst
+++ b/tests/std/test.lst
@@ -157,6 +157,7 @@ tests\Dev11_1158803_regex_thread_safety
 tests\Dev11_1180290_filesystem_error_code
 tests\GH_000457_system_error_message
 tests\GH_000545_include_compare
+tests\GH_000685_condition_variable_any
 tests\GH_000690_overaligned_function
 tests\LWG3018_shared_ptr_function
 tests\P0024R2_parallel_algorithms_adjacent_difference

--- a/tests/std/tests/GH_000685_condition_variable_any/env.lst
+++ b/tests/std/tests/GH_000685_condition_variable_any/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\native_matrix.lst

--- a/tests/std/tests/GH_000685_condition_variable_any/test.cpp
+++ b/tests/std/tests/GH_000685_condition_variable_any/test.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Test GH-685 "wait_for in condition_variable_any should unlock and lock"
+
+#include <cassert>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+using namespace std;
+
+namespace {
+    class my_mutex { // user-defined mutex type
+    public:
+        void lock() {
+            mtx.lock();
+            ++num_lock;
+        }
+
+        void unlock() {
+            mtx.unlock();
+        }
+
+        int num_locks() const {
+            return num_lock;
+        }
+
+    private:
+        mutex mtx;
+        int num_lock = 0;
+    };
+
+    const chrono::nanoseconds interval{20};
+    const chrono::nanoseconds zero_dur{0};
+
+    void test_condition_variable_any() { // test wait functions of condition variables
+        condition_variable_any cnd;
+        {
+            my_mutex mtx;
+            unique_lock<my_mutex> guard{mtx};
+
+            cnd.wait_for(mtx, zero_dur);
+            assert(mtx.num_locks() == 2);
+
+            cnd.wait_for(mtx, interval);
+            assert(mtx.num_locks() == 3);
+
+            cnd.wait_until(mtx, chrono::steady_clock::now());
+            assert(mtx.num_locks() == 4);
+
+            cnd.wait_until(mtx, chrono::steady_clock::now() + interval);
+            assert(mtx.num_locks() == 5);
+        }
+    }
+} // unnamed namespace
+
+int main() {
+    test_condition_variable_any();
+}

--- a/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy/test.cpp
@@ -56,4 +56,4 @@ struct instantiator {
     }
 };
 
-template void test_in_out<instantiator>();
+template void test_in_write<instantiator>();

--- a/tests/std/tests/P0896R4_ranges_alg_copy_if/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_if/test.cpp
@@ -17,6 +17,43 @@ struct not_pair {
     U second;
 
     auto operator<=>(const not_pair&) const = default;
+
+    template <std::size_t I>
+    constexpr friend auto&& get(not_pair& np) noexcept {
+        if constexpr (I == 0) {
+            return np.first;
+        } else {
+            STATIC_ASSERT(I == 1);
+            return np.second;
+        }
+    }
+    template <std::size_t I>
+    constexpr friend auto&& get(not_pair const& np) noexcept {
+        if constexpr (I == 0) {
+            return np.first;
+        } else {
+            STATIC_ASSERT(I == 1);
+            return np.second;
+        }
+    }
+    template <std::size_t I>
+    constexpr friend auto&& get(not_pair&& np) noexcept {
+        if constexpr (I == 0) {
+            return std::move(np).first;
+        } else {
+            STATIC_ASSERT(I == 1);
+            return std::move(np).second;
+        }
+    }
+    template <std::size_t I>
+    constexpr friend auto&& get(not_pair const&& np) noexcept {
+        if constexpr (I == 0) {
+            return std::move(np).first;
+        } else {
+            STATIC_ASSERT(I == 1);
+            return std::move(np).second;
+        }
+    }
 };
 
 constexpr void smoke_test() {
@@ -79,4 +116,4 @@ struct instantiator {
     }
 };
 
-template void test_in_out<instantiator>();
+template void test_in_write<instantiator>();

--- a/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_copy_n/test.cpp
@@ -39,4 +39,4 @@ struct instantiator {
     }
 };
 
-template void test_counted_out<instantiator>();
+template void test_counted_write<instantiator>();

--- a/tests/std/tests/P0896R4_ranges_alg_fill_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_fill_n/test.cpp
@@ -31,7 +31,7 @@ int main() {
 struct instantiator {
     template <class Out>
     static void call(Out&& out = {}) {
-        (void) ranges::fill_n(out, 13, 42);
+        (void) ranges::fill_n(ranges::begin(out), 13, 42);
     }
 };
 

--- a/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_find_first_of/test.cpp
@@ -25,33 +25,33 @@ constexpr void smoke_test() {
     const array good_needle = {29, 1};
     {
         // Validate range overload [found case]
-        const auto result = find_first_of(move_only_range{pairs}, good_needle, pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), const iterator_t<move_only_range<const P>>>);
-        assert(to_address(result.base()) == pairs.data() + 2);
+        auto result = find_first_of(move_only_range{pairs}, good_needle, pred, get_first);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<const P>>>);
+        assert(to_address(std::move(result).base()) == pairs.data() + 2);
     }
     {
         // Validate iterator + sentinel overload [found case]
         move_only_range wrapped_pairs{pairs};
-        const auto result = find_first_of(
+        auto result = find_first_of(
             wrapped_pairs.begin(), wrapped_pairs.end(), good_needle.begin(), good_needle.end(), pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), const iterator_t<move_only_range<const P>>>);
-        assert(to_address(result.base()) == pairs.data() + 2);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<const P>>>);
+        assert(to_address(std::move(result).base()) == pairs.data() + 2);
     }
 
     const array bad_needle = {29, 17};
     {
         // Validate range overload [not found case]
-        const auto result = find_first_of(move_only_range{pairs}, bad_needle, pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), const iterator_t<move_only_range<const P>>>);
-        assert(to_address(result.base()) == pairs.data() + pairs.size());
+        auto result = find_first_of(move_only_range{pairs}, bad_needle, pred, get_first);
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<const P>>>);
+        assert(to_address(std::move(result).base()) == pairs.data() + pairs.size());
     }
     {
         // Validate iterator + sentinel overload [not found case]
         move_only_range wrapped_pairs{pairs};
-        const auto result = find_first_of(
+        auto result = find_first_of(
             wrapped_pairs.begin(), wrapped_pairs.end(), bad_needle.begin(), bad_needle.end(), pred, get_first);
-        STATIC_ASSERT(same_as<decltype(result), const iterator_t<move_only_range<const P>>>);
-        assert(to_address(result.base()) == pairs.data() + pairs.size());
+        STATIC_ASSERT(same_as<decltype(result), iterator_t<move_only_range<const P>>>);
+        assert(to_address(std::move(result).base()) == pairs.data() + pairs.size());
     }
 }
 

--- a/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_alg_for_each_n/test.cpp
@@ -51,4 +51,4 @@ struct instantiator {
     }
 };
 
-template void test_counted_out<instantiator>();
+template void test_counted_write<instantiator>();

--- a/tests/std/tests/P0896R4_ranges_subrange/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_subrange/test.cpp
@@ -91,20 +91,25 @@ namespace test_view_interface {
         t[42];
     };
 
-    template <class Cat, bool Common, bool SizedSentinel, bool ConstRange>
-    struct fake_view : ranges::view_interface<fake_view<Cat, Common, SizedSentinel, ConstRange>> {
-        using iterator = test_iterator<Cat, int, SizedSentinel>;
-        using sentinel = std::conditional_t<Common, iterator, std::default_sentinel_t>;
+    using test::Common, test::CanDifference, test::CanCompare, test::ProxyRef;
+    enum class ConstRange : bool { no, yes };
 
-        iterator begin();
-        iterator begin() const requires ConstRange;
+    // clang-format off
+    template <class Cat, Common IsCommon, CanDifference Diff, ConstRange HasConstRange>
+    struct fake_view : ranges::view_interface<fake_view<Cat, IsCommon, Diff, HasConstRange>> {
+        using I = test::iterator<Cat, int, Diff, CanCompare::yes, ProxyRef::no>;
+        using S = std::conditional_t<bool(IsCommon), I, test::sentinel<int>>;
 
-        sentinel end();
-        sentinel end() const requires ConstRange;
+        I begin();
+        I begin() const requires (bool(HasConstRange));
+
+        S end();
+        S end() const requires (bool(HasConstRange));
     };
+    // clang-format on
 
     namespace output_unsized_onlymutable {
-        using V = fake_view<output_iterator_tag, false, false, false>;
+        using V = fake_view<output_iterator_tag, Common::no, CanDifference::no, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -125,7 +130,7 @@ namespace test_view_interface {
     } // namespace output_unsized_onlymutable
 
     namespace output_unsized_allowconst {
-        using V = fake_view<output_iterator_tag, false, false, true>;
+        using V = fake_view<output_iterator_tag, Common::no, CanDifference::no, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -146,7 +151,7 @@ namespace test_view_interface {
     } // namespace output_unsized_allowconst
 
     namespace output_sized_onlymutable {
-        using V = fake_view<output_iterator_tag, false, true, false>;
+        using V = fake_view<output_iterator_tag, Common::no, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -167,7 +172,7 @@ namespace test_view_interface {
     } // namespace output_sized_onlymutable
 
     namespace output_sized_allowconst {
-        using V = fake_view<output_iterator_tag, false, true, true>;
+        using V = fake_view<output_iterator_tag, Common::no, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -188,7 +193,7 @@ namespace test_view_interface {
     } // namespace output_sized_allowconst
 
     namespace input_unsized_onlymutable {
-        using V = fake_view<input_iterator_tag, false, false, false>;
+        using V = fake_view<input_iterator_tag, Common::no, CanDifference::no, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -209,7 +214,7 @@ namespace test_view_interface {
     } // namespace input_unsized_onlymutable
 
     namespace input_unsized_allowconst {
-        using V = fake_view<input_iterator_tag, false, false, true>;
+        using V = fake_view<input_iterator_tag, Common::no, CanDifference::no, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -230,7 +235,7 @@ namespace test_view_interface {
     } // namespace input_unsized_allowconst
 
     namespace input_sized_onlymutable {
-        using V = fake_view<input_iterator_tag, false, true, false>;
+        using V = fake_view<input_iterator_tag, Common::no, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -251,7 +256,7 @@ namespace test_view_interface {
     } // namespace input_sized_onlymutable
 
     namespace input_sized_allowconst {
-        using V = fake_view<input_iterator_tag, false, true, true>;
+        using V = fake_view<input_iterator_tag, Common::no, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -272,7 +277,7 @@ namespace test_view_interface {
     } // namespace input_sized_allowconst
 
     namespace forward_uncommon_unsized_onlymutable {
-        using V = fake_view<forward_iterator_tag, false, false, false>;
+        using V = fake_view<forward_iterator_tag, Common::no, CanDifference::no, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -293,7 +298,7 @@ namespace test_view_interface {
     } // namespace forward_uncommon_unsized_onlymutable
 
     namespace forward_uncommon_unsized_allowconst {
-        using V = fake_view<forward_iterator_tag, false, false, true>;
+        using V = fake_view<forward_iterator_tag, Common::no, CanDifference::no, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -314,7 +319,7 @@ namespace test_view_interface {
     } // namespace forward_uncommon_unsized_allowconst
 
     namespace forward_uncommon_sized_onlymutable {
-        using V = fake_view<forward_iterator_tag, false, true, false>;
+        using V = fake_view<forward_iterator_tag, Common::no, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -335,7 +340,7 @@ namespace test_view_interface {
     } // namespace forward_uncommon_sized_onlymutable
 
     namespace forward_uncommon_sized_allowconst {
-        using V = fake_view<forward_iterator_tag, false, true, true>;
+        using V = fake_view<forward_iterator_tag, Common::no, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -356,7 +361,7 @@ namespace test_view_interface {
     } // namespace forward_uncommon_sized_allowconst
 
     namespace forward_common_unsized_onlymutable {
-        using V = fake_view<forward_iterator_tag, true, false, false>;
+        using V = fake_view<forward_iterator_tag, Common::yes, CanDifference::no, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -377,7 +382,7 @@ namespace test_view_interface {
     } // namespace forward_common_unsized_onlymutable
 
     namespace forward_common_unsized_allowconst {
-        using V = fake_view<forward_iterator_tag, true, false, true>;
+        using V = fake_view<forward_iterator_tag, Common::yes, CanDifference::no, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -398,7 +403,7 @@ namespace test_view_interface {
     } // namespace forward_common_unsized_allowconst
 
     namespace forward_common_sized_onlymutable {
-        using V = fake_view<forward_iterator_tag, true, true, false>;
+        using V = fake_view<forward_iterator_tag, Common::yes, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -419,7 +424,7 @@ namespace test_view_interface {
     } // namespace forward_common_sized_onlymutable
 
     namespace forward_common_sized_allowconst {
-        using V = fake_view<forward_iterator_tag, true, true, true>;
+        using V = fake_view<forward_iterator_tag, Common::yes, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -440,7 +445,7 @@ namespace test_view_interface {
     } // namespace forward_common_sized_allowconst
 
     namespace bidi_uncommon_unsized_onlymutable {
-        using V = fake_view<bidirectional_iterator_tag, false, false, false>;
+        using V = fake_view<bidirectional_iterator_tag, Common::no, CanDifference::no, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -461,7 +466,7 @@ namespace test_view_interface {
     } // namespace bidi_uncommon_unsized_onlymutable
 
     namespace bidi_uncommon_unsized_allowconst {
-        using V = fake_view<bidirectional_iterator_tag, false, false, true>;
+        using V = fake_view<bidirectional_iterator_tag, Common::no, CanDifference::no, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -482,7 +487,7 @@ namespace test_view_interface {
     } // namespace bidi_uncommon_unsized_allowconst
 
     namespace bidi_uncommon_sized_onlymutable {
-        using V = fake_view<bidirectional_iterator_tag, false, true, false>;
+        using V = fake_view<bidirectional_iterator_tag, Common::no, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -503,7 +508,7 @@ namespace test_view_interface {
     } // namespace bidi_uncommon_sized_onlymutable
 
     namespace bidi_uncommon_sized_allowconst {
-        using V = fake_view<bidirectional_iterator_tag, false, true, true>;
+        using V = fake_view<bidirectional_iterator_tag, Common::no, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -524,7 +529,7 @@ namespace test_view_interface {
     } // namespace bidi_uncommon_sized_allowconst
 
     namespace bidi_common_unsized_onlymutable {
-        using V = fake_view<bidirectional_iterator_tag, true, false, false>;
+        using V = fake_view<bidirectional_iterator_tag, Common::yes, CanDifference::no, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -545,7 +550,7 @@ namespace test_view_interface {
     } // namespace bidi_common_unsized_onlymutable
 
     namespace bidi_common_unsized_allowconst {
-        using V = fake_view<bidirectional_iterator_tag, true, false, true>;
+        using V = fake_view<bidirectional_iterator_tag, Common::yes, CanDifference::no, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -566,7 +571,7 @@ namespace test_view_interface {
     } // namespace bidi_common_unsized_allowconst
 
     namespace bidi_common_sized_onlymutable {
-        using V = fake_view<bidirectional_iterator_tag, true, true, false>;
+        using V = fake_view<bidirectional_iterator_tag, Common::yes, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -587,7 +592,7 @@ namespace test_view_interface {
     } // namespace bidi_common_sized_onlymutable
 
     namespace bidi_common_sized_allowconst {
-        using V = fake_view<bidirectional_iterator_tag, true, true, true>;
+        using V = fake_view<bidirectional_iterator_tag, Common::yes, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -607,50 +612,8 @@ namespace test_view_interface {
         STATIC_ASSERT(!CanIndex<V const>);
     } // namespace bidi_common_sized_allowconst
 
-    namespace random_uncommon_unsized_onlymutable {
-        using V = fake_view<random_access_iterator_tag, false, false, false>;
-        STATIC_ASSERT(ranges::range<V>);
-        STATIC_ASSERT(!ranges::range<V const>);
-        STATIC_ASSERT(ranges::view<V>);
-        STATIC_ASSERT(CanEmpty<V>);
-        STATIC_ASSERT(!CanEmpty<V const>);
-        STATIC_ASSERT(CanBool<V>);
-        STATIC_ASSERT(!CanBool<V const>);
-        STATIC_ASSERT(!CanData<V>);
-        STATIC_ASSERT(!CanData<V const>);
-        STATIC_ASSERT(!CanSize<V>);
-        STATIC_ASSERT(!CanSize<V const>);
-        STATIC_ASSERT(CanFront<V>);
-        STATIC_ASSERT(!CanFront<V const>);
-        STATIC_ASSERT(!CanBack<V>);
-        STATIC_ASSERT(!CanBack<V const>);
-        STATIC_ASSERT(CanIndex<V>);
-        STATIC_ASSERT(!CanIndex<V const>);
-    } // namespace random_uncommon_unsized_onlymutable
-
-    namespace random_uncommon_unsized_allowconst {
-        using V = fake_view<random_access_iterator_tag, false, false, true>;
-        STATIC_ASSERT(ranges::range<V>);
-        STATIC_ASSERT(ranges::range<V const>);
-        STATIC_ASSERT(ranges::view<V>);
-        STATIC_ASSERT(CanEmpty<V>);
-        STATIC_ASSERT(CanEmpty<V const>);
-        STATIC_ASSERT(CanBool<V>);
-        STATIC_ASSERT(CanBool<V const>);
-        STATIC_ASSERT(!CanData<V>);
-        STATIC_ASSERT(!CanData<V const>);
-        STATIC_ASSERT(!CanSize<V>);
-        STATIC_ASSERT(!CanSize<V const>);
-        STATIC_ASSERT(CanFront<V>);
-        STATIC_ASSERT(CanFront<V const>);
-        STATIC_ASSERT(!CanBack<V>);
-        STATIC_ASSERT(!CanBack<V const>);
-        STATIC_ASSERT(CanIndex<V>);
-        STATIC_ASSERT(CanIndex<V const>);
-    } // namespace random_uncommon_unsized_allowconst
-
     namespace random_uncommon_sized_onlymutable {
-        using V = fake_view<random_access_iterator_tag, false, true, false>;
+        using V = fake_view<random_access_iterator_tag, Common::no, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -671,7 +634,7 @@ namespace test_view_interface {
     } // namespace random_uncommon_sized_onlymutable
 
     namespace random_uncommon_sized_allowconst {
-        using V = fake_view<random_access_iterator_tag, false, true, true>;
+        using V = fake_view<random_access_iterator_tag, Common::no, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -692,7 +655,7 @@ namespace test_view_interface {
     } // namespace random_uncommon_sized_allowconst
 
     namespace random_common_sized_onlymutable {
-        using V = fake_view<random_access_iterator_tag, true, true, false>;
+        using V = fake_view<random_access_iterator_tag, Common::yes, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -713,7 +676,7 @@ namespace test_view_interface {
     } // namespace random_common_sized_onlymutable
 
     namespace random_common_sized_allowconst {
-        using V = fake_view<random_access_iterator_tag, true, true, true>;
+        using V = fake_view<random_access_iterator_tag, Common::yes, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -733,50 +696,8 @@ namespace test_view_interface {
         STATIC_ASSERT(CanIndex<V const>);
     } // namespace random_common_sized_allowconst
 
-    namespace contiguous_uncommon_unsized_onlymutable {
-        using V = fake_view<contiguous_iterator_tag, false, false, false>;
-        STATIC_ASSERT(ranges::range<V>);
-        STATIC_ASSERT(!ranges::range<V const>);
-        STATIC_ASSERT(ranges::view<V>);
-        STATIC_ASSERT(CanEmpty<V>);
-        STATIC_ASSERT(!CanEmpty<V const>);
-        STATIC_ASSERT(CanBool<V>);
-        STATIC_ASSERT(!CanBool<V const>);
-        STATIC_ASSERT(CanData<V>);
-        STATIC_ASSERT(!CanData<V const>);
-        STATIC_ASSERT(!CanSize<V>);
-        STATIC_ASSERT(!CanSize<V const>);
-        STATIC_ASSERT(CanFront<V>);
-        STATIC_ASSERT(!CanFront<V const>);
-        STATIC_ASSERT(!CanBack<V>);
-        STATIC_ASSERT(!CanBack<V const>);
-        STATIC_ASSERT(CanIndex<V>);
-        STATIC_ASSERT(!CanIndex<V const>);
-    } // namespace contiguous_uncommon_unsized_onlymutable
-
-    namespace contiguous_uncommon_unsized_allowconst {
-        using V = fake_view<contiguous_iterator_tag, false, false, true>;
-        STATIC_ASSERT(ranges::range<V>);
-        STATIC_ASSERT(ranges::range<V const>);
-        STATIC_ASSERT(ranges::view<V>);
-        STATIC_ASSERT(CanEmpty<V>);
-        STATIC_ASSERT(CanEmpty<V const>);
-        STATIC_ASSERT(CanBool<V>);
-        STATIC_ASSERT(CanBool<V const>);
-        STATIC_ASSERT(CanData<V>);
-        STATIC_ASSERT(CanData<V const>);
-        STATIC_ASSERT(!CanSize<V>);
-        STATIC_ASSERT(!CanSize<V const>);
-        STATIC_ASSERT(CanFront<V>);
-        STATIC_ASSERT(CanFront<V const>);
-        STATIC_ASSERT(!CanBack<V>);
-        STATIC_ASSERT(!CanBack<V const>);
-        STATIC_ASSERT(CanIndex<V>);
-        STATIC_ASSERT(CanIndex<V const>);
-    } // namespace contiguous_uncommon_unsized_allowconst
-
     namespace contiguous_uncommon_sized_onlymutable {
-        using V = fake_view<contiguous_iterator_tag, false, true, false>;
+        using V = fake_view<contiguous_iterator_tag, Common::no, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -797,7 +718,7 @@ namespace test_view_interface {
     } // namespace contiguous_uncommon_sized_onlymutable
 
     namespace contiguous_uncommon_sized_allowconst {
-        using V = fake_view<contiguous_iterator_tag, false, true, true>;
+        using V = fake_view<contiguous_iterator_tag, Common::no, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -818,7 +739,7 @@ namespace test_view_interface {
     } // namespace contiguous_uncommon_sized_allowconst
 
     namespace contiguous_common_sized_onlymutable {
-        using V = fake_view<contiguous_iterator_tag, true, true, false>;
+        using V = fake_view<contiguous_iterator_tag, Common::yes, CanDifference::yes, ConstRange::no>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(!ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -839,7 +760,7 @@ namespace test_view_interface {
     } // namespace contiguous_common_sized_onlymutable
 
     namespace contiguous_common_sized_allowconst {
-        using V = fake_view<contiguous_iterator_tag, true, true, true>;
+        using V = fake_view<contiguous_iterator_tag, Common::yes, CanDifference::yes, ConstRange::yes>;
         STATIC_ASSERT(ranges::range<V>);
         STATIC_ASSERT(ranges::range<V const>);
         STATIC_ASSERT(ranges::view<V>);
@@ -896,9 +817,8 @@ namespace test_subrange {
     STATIC_ASSERT(same_as<subrange<int*>, subrange<int*, int*, subrange_kind::sized>>);
     STATIC_ASSERT(same_as<subrange<int*, std::unreachable_sentinel_t>,
         subrange<int*, std::unreachable_sentinel_t, subrange_kind::unsized>>);
-    STATIC_ASSERT(same_as<subrange<test_iterator<forward_iterator_tag, int>>,
-        subrange<test_iterator<forward_iterator_tag, int>, test_iterator<forward_iterator_tag, int>,
-            subrange_kind::unsized>>);
+    STATIC_ASSERT(same_as<subrange<std::forward_list<int>::iterator>,
+        subrange<std::forward_list<int>::iterator, std::forward_list<int>::iterator, subrange_kind::unsized>>);
 
     // Validate many properties of a specialization of subrange
     template <class>
@@ -965,22 +885,198 @@ namespace test_subrange {
 
         return true;
     }
-    STATIC_ASSERT(test_construction<test_range<output_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_construction<test_range<output_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_construction<test_range<input_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_construction<test_range<input_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_construction<test_range<forward_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_construction<test_range<forward_iterator_tag, int, false, true>>());
-    STATIC_ASSERT(test_construction<test_range<forward_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_construction<test_range<forward_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_construction<test_range<bidirectional_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_construction<test_range<bidirectional_iterator_tag, int, false, true>>());
-    STATIC_ASSERT(test_construction<test_range<bidirectional_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_construction<test_range<bidirectional_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_construction<test_range<random_access_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_construction<test_range<random_access_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_construction<test_range<contiguous_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_construction<test_range<contiguous_iterator_tag, int, true, true>>());
+
+    using test::CanCompare, test::CanDifference, test::Common, test::ProxyRef, test::Sized;
+
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no,
+            Common::no, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no,
+            Common::yes, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no,
+            Common::no, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no,
+            Common::yes, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::yes>>());
+
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::yes>>());
+
+    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, Sized::no, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::no, CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_construction<test::range<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes,
+            Common::yes, CanCompare::yes, ProxyRef::no>>());
 
     STATIC_ASSERT(test_construction<std::forward_list<int>>());
     STATIC_ASSERT(test_construction<std::list<int>>());
@@ -1113,22 +1209,214 @@ namespace test_subrange {
 
         return true;
     }
-    STATIC_ASSERT(test_ctad<test_range<output_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_ctad<test_range<output_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test_range<input_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_ctad<test_range<input_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test_range<forward_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_ctad<test_range<forward_iterator_tag, int, false, true>>());
-    STATIC_ASSERT(test_ctad<test_range<forward_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test_range<forward_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_ctad<test_range<bidirectional_iterator_tag, int, false, false>>());
-    STATIC_ASSERT(test_ctad<test_range<bidirectional_iterator_tag, int, false, true>>());
-    STATIC_ASSERT(test_ctad<test_range<bidirectional_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test_range<bidirectional_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_ctad<test_range<random_access_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test_range<random_access_iterator_tag, int, true, true>>());
-    STATIC_ASSERT(test_ctad<test_range<contiguous_iterator_tag, int, true, false>>());
-    STATIC_ASSERT(test_ctad<test_range<contiguous_iterator_tag, int, true, true>>());
+
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::no, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::yes>>());
+
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, Sized::no, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no,
+            CanCompare::yes, ProxyRef::no>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes,
+            CanCompare::yes, ProxyRef::no>>());
+
+    STATIC_ASSERT(
+        test_ctad<test::range<output_iterator_tag, int, Sized::no, CanDifference::no>>()); // FIXME: look at these
+    STATIC_ASSERT(test_ctad<test::range<output_iterator_tag, int, Sized::yes, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::no, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<input_iterator_tag, int, Sized::yes, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::no, CanDifference::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<forward_iterator_tag, int, Sized::yes, CanDifference::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<random_access_iterator_tag, int, Sized::yes, CanDifference::yes>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, Sized::yes, CanDifference::no>>());
+    STATIC_ASSERT(test_ctad<test::range<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes>>());
 
     STATIC_ASSERT(test_ctad<std::forward_list<int>>());
     STATIC_ASSERT(test_ctad<std::list<int>>());

--- a/tests/std/tests/P0896R4_ranges_test_machinery/env.lst
+++ b/tests/std/tests/P0896R4_ranges_test_machinery/env.lst
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+RUNALL_INCLUDE ..\concepts_matrix.lst

--- a/tests/std/tests/P0896R4_ranges_test_machinery/test.cpp
+++ b/tests/std/tests/P0896R4_ranges_test_machinery/test.cpp
@@ -1,0 +1,400 @@
+// Copyright (c) Microsoft Corporation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <concepts>
+#include <ranges>
+//
+#include <range_algorithm_support.hpp>
+
+#define STATIC_ASSERT(...) static_assert(__VA_ARGS__, #__VA_ARGS__)
+
+using namespace std;
+
+int main() {} // COMPILE-ONLY
+
+using test::CanDifference, test::CanCompare, test::ProxyRef, test::IsWrapped;
+
+// Validate test::iterator and test::sentinel
+template <class Category, class Element, CanDifference Diff, CanCompare Eq, ProxyRef Proxy, IsWrapped Wrapped>
+constexpr bool iter_test() {
+    using test::iterator, test::sentinel;
+
+    using I = iterator<Category, Element, Diff, Eq, Proxy, Wrapped>;
+
+    STATIC_ASSERT(default_initializable<I>);
+    STATIC_ASSERT(movable<I>);
+
+    STATIC_ASSERT(!movable<Element> || indirectly_writable<I, Element>);
+
+    constexpr bool can_write =
+        derived_from<Category,
+            output_iterator_tag> || (derived_from<Category, forward_iterator_tag> && assignable_from<Element&, Element>);
+    STATIC_ASSERT(!can_write || output_iterator<I, Element>);
+
+    STATIC_ASSERT(!derived_from<Category, input_iterator_tag> || input_iterator<I>);
+    STATIC_ASSERT(!derived_from<Category, forward_iterator_tag> || forward_iterator<I>);
+    STATIC_ASSERT(!derived_from<Category, bidirectional_iterator_tag> || bidirectional_iterator<I>);
+    STATIC_ASSERT(!derived_from<Category, random_access_iterator_tag> || random_access_iterator<I>);
+    STATIC_ASSERT(!derived_from<Category, contiguous_iterator_tag> || contiguous_iterator<I>);
+
+    using S = sentinel<Element, Wrapped>;
+    STATIC_ASSERT(sentinel_for<S, I>);
+    STATIC_ASSERT(!bool(Diff) || sized_sentinel_for<S, I>);
+    STATIC_ASSERT(!bool(Eq) || sentinel_for<I, I>);
+    STATIC_ASSERT(!bool(Eq) || !bool(Diff) || sized_sentinel_for<I, I>);
+
+    if constexpr (bool(Wrapped)) {
+        STATIC_ASSERT(same_as<_Unwrapped_t<I>, iterator<Category, Element, Diff, Eq, Proxy, IsWrapped::no>>);
+        STATIC_ASSERT(same_as<_Unwrapped_t<S>, sentinel<Element, IsWrapped::no>>);
+    }
+
+    return true;
+}
+
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<output_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::no, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::no, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(iter_test<input_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<forward_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(iter_test<forward_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<forward_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<forward_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<forward_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<bidirectional_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<random_access_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::yes, IsWrapped::yes>());
+
+STATIC_ASSERT(
+    iter_test<contiguous_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<contiguous_iterator_tag, int, CanDifference::no, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+STATIC_ASSERT(
+    iter_test<contiguous_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::no>());
+STATIC_ASSERT(
+    iter_test<contiguous_iterator_tag, int, CanDifference::yes, CanCompare::yes, ProxyRef::no, IsWrapped::yes>());
+
+STATIC_ASSERT(same_as<_Unwrapped_t<test::sentinel<int, IsWrapped::yes>>, test::sentinel<int, IsWrapped::no>>);
+
+// Validate test::range
+// clang-format off
+template <class R>
+concept has_member_size = requires(const R& r) {
+    typename ranges::range_size_t<R>;
+    { r.size() } -> same_as<ranges::range_size_t<R>>;
+};
+// clang-format on
+
+using test::Sized, test::Common;
+
+template <class Category, class Element, Sized IsSized, CanDifference Diff, Common IsCommon, CanCompare Eq,
+    ProxyRef Proxy>
+constexpr bool range_test() {
+    using R = test::range<Category, Element, IsSized, Diff, IsCommon, Eq, Proxy>;
+    using I = ranges::iterator_t<R>;
+    using S = ranges::sentinel_t<R>;
+    STATIC_ASSERT(same_as<I, test::iterator<Category, Element, Diff, Eq, Proxy, IsWrapped::yes>>);
+
+    STATIC_ASSERT(!derived_from<Category, output_iterator_tag> || ranges::output_range<R, Element>);
+    STATIC_ASSERT(!derived_from<Category, input_iterator_tag> || ranges::input_range<R>);
+    STATIC_ASSERT(!derived_from<Category, forward_iterator_tag> || ranges::forward_range<R>);
+    STATIC_ASSERT(!derived_from<Category, bidirectional_iterator_tag> || ranges::bidirectional_range<R>);
+    STATIC_ASSERT(!derived_from<Category, random_access_iterator_tag> || ranges::random_access_range<R>);
+    STATIC_ASSERT(!derived_from<Category, contiguous_iterator_tag> || ranges::contiguous_range<R>);
+
+    if constexpr (bool(IsCommon)) {
+        STATIC_ASSERT(bool(Eq));
+        STATIC_ASSERT(ranges::common_range<R>);
+    } else {
+        STATIC_ASSERT(same_as<S, test::sentinel<Element, IsWrapped::yes>>);
+    }
+
+    STATIC_ASSERT(!bool(Eq) || sentinel_for<I, I>);
+
+    constexpr bool is_sized = bool(IsSized) || (bool(Diff) && derived_from<Category, forward_iterator_tag>);
+    STATIC_ASSERT(ranges::sized_range<R> == is_sized);
+    if constexpr (bool(IsSized)) {
+        STATIC_ASSERT(has_member_size<R>);
+    }
+
+    return true;
+}
+
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(range_test<output_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::no, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<input_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::yes>());
+
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes, ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(
+    range_test<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes, ProxyRef::no>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<forward_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::no, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::no, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<bidirectional_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::yes>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<random_access_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::yes>());
+
+STATIC_ASSERT(range_test<contiguous_iterator_tag, int, Sized::no, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<contiguous_iterator_tag, int, Sized::no, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes, Common::no, CanCompare::yes,
+    ProxyRef::no>());
+STATIC_ASSERT(range_test<contiguous_iterator_tag, int, Sized::yes, CanDifference::yes, Common::yes, CanCompare::yes,
+    ProxyRef::no>());
+
+// Validate move_only_range
+STATIC_ASSERT(ranges::input_range<move_only_range<int>>);
+STATIC_ASSERT(!ranges::forward_range<move_only_range<int>>);
+STATIC_ASSERT(movable<move_only_range<int>>);
+STATIC_ASSERT(!copyable<move_only_range<int>>);
+
+struct instantiate {
+    template <class Range1, class Range2>
+    static constexpr void call() {
+        STATIC_ASSERT(ranges::input_range<Range1>);
+        STATIC_ASSERT(same_as<ranges::range_value_t<Range1>, double>);
+        STATIC_ASSERT(indirectly_writable<ranges::iterator_t<Range1>, const double&>);
+
+        STATIC_ASSERT(ranges::input_range<Range2>);
+        STATIC_ASSERT(same_as<ranges::range_value_t<Range2>, void*>);
+        STATIC_ASSERT(!indirectly_writable<ranges::iterator_t<Range2>, void*>);
+    }
+};
+
+template void test_in_in<instantiate, double, void* const>();

--- a/tests/tr1/tests/chrono/test.cpp
+++ b/tests/tr1/tests/chrono/test.cpp
@@ -297,7 +297,7 @@ namespace {
         }
     }
 
-} // anonymous namespace
+} // unnamed namespace
 
 void test_main() {
     t_common_type();

--- a/tests/tr1/tests/condition_variable/test.cpp
+++ b/tests/tr1/tests/condition_variable/test.cpp
@@ -13,7 +13,7 @@
 #include <system_error>
 #include <thread>
 
-namespace { // anonymous namespace
+namespace {
     int count;
     int value;
     STD mutex sync_mutex;
@@ -309,7 +309,7 @@ namespace { // anonymous namespace
         my_mutex mtx4;
         t_condition_variables(cnd, mtx4, "my_mutex");
     }
-} // anonymous namespace
+} // unnamed namespace
 
 void test_main() { // test header <condition_variable>
     t_condition_variable();

--- a/tests/tr1/tests/ratio/test.cpp
+++ b/tests/tr1/tests/ratio/test.cpp
@@ -359,7 +359,7 @@ namespace {
         CHECK_INT(yotta_test::value, true);
 #endif // 1000000 <= INTMAX_MAX / 1000000000000000000
     }
-} // anonymous namespace
+} // unnamed namespace
 
 void test_main() { // test header <ratio>
     t_ratio();

--- a/tests/tr1/tests/thread/test.cpp
+++ b/tests/tr1/tests/thread/test.cpp
@@ -341,7 +341,7 @@ namespace {
             CHECK_INT(tgt <= STD chrono::system_clock::now(), true);
         }
     }
-} // anonymous namespace
+} // unnamed namespace
 
 void test_main() { // test header <thread>
     if (!terse) { // display value of __STDCPP_THREADS__


### PR DESCRIPTION
by merging `origin/master`, and fix a couple of issues needed to get the tests to run:

* `++_UFirst, --_Count` in `fill_n` triggers the "evil" `operator,` overload in `range_algorithm_support.hpp` that exists specifically to ensure that algorithms guard against operator hijacking. Add the `(void)` cast necessary to avoid hijacking.

* `test_out` instantiates with output ranges - not output iterators - so `fill_n`'s `instantiator::call` needs to call `begin` in the `out` parameter to get an iterator.

(To be clear: I'm not trying to take these over, but to fix the mess I made of your branches with my heavy rework of the `test::range` stuff.)